### PR TITLE
Paying down technical debt

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -345,6 +345,9 @@ Binged on cleaning up technical debt in the build system. The goal of separating
     1544474   12024   43940 1600438  186bb6 New baseline.
     1544102   12024   43940 1600066  186a42 Excision of xport_id. It is no longer needed.
     1544070   12024   43940 1600034  186a22 Class member re-arrangement.
+    1544086   12024   43940 1600050  186a32 Kernel cleanup.
+    1544198   12024   43940 1600162  186aa2 Reintroducing wakeThread() for Kernel.
+
 
 The ManuvrRunnable namespace died at 03:59 PST on 2016.10.09. A brief re-cap of its evolution feels appropriate.
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -346,4 +346,13 @@ Binged on cleaning up technical debt in the build system. The goal of separating
     1544102   12024   43940 1600066  186a42 Excision of xport_id. It is no longer needed.
     1544070   12024   43940 1600034  186a22 Class member re-arrangement.
 
+The ManuvrRunnable namespace died at 03:59 PST on 2016.10.09. A brief re-cap of its evolution feels appropriate.
+
+In the beginning, there was ScheduleItem, ManuvrMsg, and Event (which was the child of ManuvrMsg). Each did its own specific job, and for a time, it was good.
+
+Then, much complexity was built around scheduling events. Darkness settled over the code base. Dissatisfied with the uneasy truce between ScheduleItem and Event, the monarch forged the two into one hasty blob and named it ManuvrRunnable (which still extended ManuvrMsg).
+
+This worked for awhile, but was only a thin veneer over the disharmony between the two original houses. True resolution of the split happened gradually over many ages (about twelve months).  The final battle was waged today between ManuvrMsg and ManuvrRunnable on the battlefield of "Namespace". ManuvrMsg was the victor.
+
+
 _---J. Ian Lindsay_

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -330,4 +330,11 @@ mbedtls completely out as *the* dependency for cryptography.
     Linux, 32-bit: DEBUG=1 SECURE=1
     1777199   12204   52324 1841727  1c1a3f New baseline.
 
+------
+
+### 2016.10.07:
+
+    Linux, 32-bit: DEBUG=1 SECURE=1
+    1544566   12024   43940 1600530  186c12 Following semantic_args excision.
+
 _---J. Ian Lindsay_

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -336,5 +336,6 @@ mbedtls completely out as *the* dependency for cryptography.
 
     Linux, 32-bit: DEBUG=1 SECURE=1
     1544566   12024   43940 1600530  186c12 Following semantic_args excision.
-
+    1544566   12024   43940 1600530  186c12 Removal of redundant thread_id member had no effect.
+    1544586   12024   43940 1600550  186c26 Removal of kernel pointer from ER (safety).
 _---J. Ian Lindsay_

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -338,4 +338,12 @@ mbedtls completely out as *the* dependency for cryptography.
     1544566   12024   43940 1600530  186c12 Following semantic_args excision.
     1544566   12024   43940 1600530  186c12 Removal of redundant thread_id member had no effect.
     1544586   12024   43940 1600550  186c26 Removal of kernel pointer from ER (safety).
+
+Binged on cleaning up technical debt in the build system. The goal of separating threading concerns from platform was advanced. More crypto-wrapper sanity-checking.
+
+    Linux, 32-bit: DEBUG=1 SECURE=1
+    1544474   12024   43940 1600438  186bb6 New baseline.
+    1544102   12024   43940 1600066  186a42 Excision of xport_id. It is no longer needed.
+
+
 _---J. Ian Lindsay_

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -344,6 +344,6 @@ Binged on cleaning up technical debt in the build system. The goal of separating
     Linux, 32-bit: DEBUG=1 SECURE=1
     1544474   12024   43940 1600438  186bb6 New baseline.
     1544102   12024   43940 1600066  186a42 Excision of xport_id. It is no longer needed.
-
+    1544070   12024   43940 1600034  186a22 Class member re-arrangement.
 
 _---J. Ian Lindsay_

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ export AR      = $(shell which ar)
 export SZ      = $(shell which size)
 export MAKE    = $(shell which make)
 
-export OUTPUT_PATH = $(BUILD_ROOT)/build/
+# This is where we will store compiled libs and the final output.
 export BUILD_ROOT  = $(shell pwd)
+export OUTPUT_PATH = $(BUILD_ROOT)/build/
 
 
 ###########################################################################

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ MANUVR_OPTIONS     =
 # Environmental awareness...
 ###########################################################################
 SHELL          = /bin/sh
-WHERE_I_AM     = $(shell pwd)
 
 export CC      = $(shell which gcc)
 export CXX     = $(shell which g++)
@@ -30,25 +29,26 @@ export AR      = $(shell which ar)
 export SZ      = $(shell which size)
 export MAKE    = $(shell which make)
 
-export OUTPUT_PATH = $(WHERE_I_AM)/build/
+export OUTPUT_PATH = $(BUILD_ROOT)/build/
+export BUILD_ROOT  = $(shell pwd)
 
 
 ###########################################################################
 # Source files, includes, and linker directives...
 ###########################################################################
-INCLUDES    = -I$(WHERE_I_AM)/.
-INCLUDES   += -I$(WHERE_I_AM)/ManuvrOS
-INCLUDES   += -I$(WHERE_I_AM)/lib
+INCLUDES    = -I$(BUILD_ROOT)/.
+INCLUDES   += -I$(BUILD_ROOT)/ManuvrOS
+INCLUDES   += -I$(BUILD_ROOT)/lib
 
-INCLUDES   += -I$(WHERE_I_AM)/lib/paho.mqtt.embedded-c/
-INCLUDES   += -I$(WHERE_I_AM)/lib/mbedtls/include/
-INCLUDES   += -I$(WHERE_I_AM)/lib/iotivity
-INCLUDES   += -I$(WHERE_I_AM)/lib/iotivity/include
+INCLUDES   += -I$(BUILD_ROOT)/lib/paho.mqtt.embedded-c/
+INCLUDES   += -I$(BUILD_ROOT)/lib/mbedtls/include/
+INCLUDES   += -I$(BUILD_ROOT)/lib/iotivity
+INCLUDES   += -I$(BUILD_ROOT)/lib/iotivity/include
 
 # Libraries to link
 # We should be gradually phasing out C++ standard library on linux builds.
 # TODO: Advance this goal.
-LIBS = -L$(OUTPUT_PATH) -L$(WHERE_I_AM)/lib -lstdc++ -lm
+LIBS = -L$(OUTPUT_PATH) -L$(BUILD_ROOT)/lib -lstdc++ -lm
 
 # Wrap the include paths into the flags...
 CFLAGS += $(INCLUDES)

--- a/ManuvrOS/CommonConstants.h
+++ b/ManuvrOS/CommonConstants.h
@@ -41,6 +41,18 @@ Apart from including the user-suppied configuration header, there
   #define LOG_INFO    6    /* informational */
   #define LOG_DEBUG   7    /* debug-level messages */
 
+
+  #if defined(MANUVR_CONSOLE_SUPPORT)
+    #if defined(__MANUVR_DEBUG)
+      #define DEFAULT_CLASS_VERBOSITY    6
+    #else
+      #define DEFAULT_CLASS_VERBOSITY    4
+    #endif
+  #else
+    #define DEFAULT_CLASS_VERBOSITY      0
+  #endif
+
+
   /*
   * These are defines for const char* that are commonly used.
   * We are collecting them here so that future additions to the
@@ -70,14 +82,18 @@ int wrapped_base64_decode(uint8_t* dst, size_t dlen, size_t* olen, const uint8_t
 inline float    strict_max(float    a, float    b) {  return (a > b) ? a : b; };
 inline uint32_t strict_max(uint32_t a, uint32_t b) {  return (a > b) ? a : b; };
 inline uint16_t strict_max(uint16_t a, uint16_t b) {  return (a > b) ? a : b; };
+inline uint8_t  strict_max(uint8_t  a, uint8_t  b) {  return (a > b) ? a : b; };
 inline int32_t  strict_max(int32_t  a, int32_t  b) {  return (a > b) ? a : b; };
 inline int16_t  strict_max(int16_t  a, int16_t  b) {  return (a > b) ? a : b; };
+inline int8_t   strict_max(int8_t   a, int8_t   b) {  return (a > b) ? a : b; };
 
 inline float    strict_min(float    a, float    b) {  return (a < b) ? a : b; };
 inline uint32_t strict_min(uint32_t a, uint32_t b) {  return (a < b) ? a : b; };
 inline uint16_t strict_min(uint16_t a, uint16_t b) {  return (a < b) ? a : b; };
+inline uint8_t  strict_min(uint8_t  a, uint8_t  b) {  return (a < b) ? a : b; };
 inline int32_t  strict_min(int32_t  a, int32_t  b) {  return (a < b) ? a : b; };
 inline int16_t  strict_min(int16_t  a, int16_t  b) {  return (a < b) ? a : b; };
+inline int8_t   strict_min(int8_t   a, int8_t   b) {  return (a < b) ? a : b; };
 
 inline uint32_t wrap_accounted_delta(uint32_t a, uint32_t b) {
   return (a > b) ? (a - b) : (b - a);

--- a/ManuvrOS/CommonConstants.h
+++ b/ManuvrOS/CommonConstants.h
@@ -63,7 +63,9 @@ Apart from including the user-suppied configuration header, there
 
 
 // TODO: Function defs do not belong here. This area under re-org.
+#if defined(__BUILD_HAS_BASE64)
 int wrapped_base64_decode(uint8_t* dst, size_t dlen, size_t* olen, const uint8_t* src, size_t slen);
+#endif
 // Everytime you macro a function, baby Jesus cries.
 inline float    strict_max(float    a, float    b) {  return (a > b) ? a : b; };
 inline uint32_t strict_max(uint32_t a, uint32_t b) {  return (a > b) ? a : b; };

--- a/ManuvrOS/DataStructures/Argument.cpp
+++ b/ManuvrOS/DataStructures/Argument.cpp
@@ -374,7 +374,7 @@ int8_t Argument::getValueAs(void* trg_buf) {
       case STR_BUILDER_FM:          // This is a pointer to some StringBuilder. Presumably this is on the heap.
       case STR_FM:                  // This is a pointer to a string constant. Presumably this is stored in flash.
       case BUFFERPIPE_PTR_FM:       // This is a pointer to a BufferPipe/.
-      case SYS_RUNNABLE_PTR_FM:     // This is a pointer to ManuvrMsg.
+      case SYS_MANUVRMSG_FM:     // This is a pointer to ManuvrMsg.
       case SYS_EVENTRECEIVER_FM:    // This is a pointer to an EventReceiver.
       case SYS_MANUVR_XPORT_FM:     // This is a pointer to a transport.
       default:

--- a/ManuvrOS/DataStructures/Argument.h
+++ b/ManuvrOS/DataStructures/Argument.h
@@ -92,7 +92,7 @@ class Argument {
     * We typically want ManuvrMsg references to be left alone at the end of
     *   the Argument's life cycle. We will specify otherwise when appropriate.
     */
-    Argument(ManuvrMsg* val) : Argument((void*) val, sizeof(val), SYS_RUNNABLE_PTR_FM) {};
+    Argument(ManuvrMsg* val) : Argument((void*) val, sizeof(val), SYS_MANUVRMSG_FM) {};
 
     // TODO: This default behavior changed. Audit usage by commenting addArg(StringBuilder)
     Argument(StringBuilder* val)  : Argument(val, sizeof(val), STR_BUILDER_FM)          {};
@@ -158,7 +158,7 @@ class Argument {
     inline Argument* append(BufferPipe *val) {      return link(new Argument(val));   }
     inline Argument* append(EventReceiver *val) {   return link(new Argument(val));   }
     inline Argument* append(ManuvrXport *val) {     return link(new Argument(val));   }
-    inline Argument* append(ManuvrMsg *val) {  return link(new Argument(val));   }
+    inline Argument* append(ManuvrMsg* val) {  return link(new Argument(val));   }
 
     inline Argument* append(FxnPointer *val) {      return link(new Argument(val));   }
     inline Argument* append(ThreadFxnPtr *val) {    return link(new Argument(val));   }

--- a/ManuvrOS/DataStructures/uuid.cpp
+++ b/ManuvrOS/DataStructures/uuid.cpp
@@ -133,24 +133,33 @@ void uuid_gen(UUID *uuid) {
 * Returns 0 if the given UUIDs are the same value.
 */
 int uuid_compare(UUID *uuid0, UUID *uuid1) {
-  if (*((uint32_t*) &uuid0->id[0]) == *((uint32_t*) &uuid1->id[0])) {
-    if (*((uint32_t*) &uuid0->id[4]) == *((uint32_t*) &uuid1->id[4])) {
-      if (*((uint32_t*) &uuid0->id[8]) == *((uint32_t*) &uuid1->id[8])) {
-        if (*((uint32_t*) &uuid0->id[12]) == *((uint32_t*) &uuid1->id[12])) {
-          return 0;
-        }
-      }
+  for (int i = 0; i  < 16; i++) {
+    if ((uuid0->id[i]) != uuid1->id[i]) {
+      return 1;
     }
   }
-  return 1;
+  return 0;
+  // TODO: Commented code should be faster, but might break aliasing.
+  //if (*((uint32_t*) &uuid0->id[0]) == *((uint32_t*) &uuid1->id[0])) {
+  //  if (*((uint32_t*) &uuid0->id[4]) == *((uint32_t*) &uuid1->id[4])) {
+  //    if (*((uint32_t*) &uuid0->id[8]) == *((uint32_t*) &uuid1->id[8])) {
+  //      if (*((uint32_t*) &uuid0->id[12]) == *((uint32_t*) &uuid1->id[12])) {
+  //        return 0;
+  //      }
+  //    }
+  //  }
+  //}
+  //return 1;
 }
 
 
 void uuid_copy(UUID* src, UUID* dest) {
-  *((uint32_t*) &dest->id[0])  = *((uint32_t*) &src->id[0]);
-  *((uint32_t*) &dest->id[4])  = *((uint32_t*) &src->id[4]);
-  *((uint32_t*) &dest->id[8])  = *((uint32_t*) &src->id[8]);
-  *((uint32_t*) &dest->id[12]) = *((uint32_t*) &src->id[12]);
+  memcpy(&dest->id[0], &src->id[0], 16);
+  // TODO: Commented code should be faster, but might break aliasing.
+  //*((uint32_t*) &dest->id[0])  = *((uint32_t*) &src->id[0]);
+  //*((uint32_t*) &dest->id[4])  = *((uint32_t*) &src->id[4]);
+  //*((uint32_t*) &dest->id[8])  = *((uint32_t*) &src->id[8]);
+  //*((uint32_t*) &dest->id[12]) = *((uint32_t*) &src->id[12]);
 }
 
 

--- a/ManuvrOS/DataStructures/uuid.h
+++ b/ManuvrOS/DataStructures/uuid.h
@@ -31,7 +31,9 @@
 
 typedef struct {
   uint8_t id[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-} UUID;
+} UUID __attribute__ ((aligned (4)));
+
+
 
 void uuid_from_str(const char *str, UUID*);
 void uuid_to_str(const UUID*, char *buffer, int buflen);

--- a/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
+++ b/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
@@ -44,7 +44,7 @@ ADCScanner::ADCScanner() : EventReceiver() {
 
 ADCScanner::~ADCScanner() {
   _periodic_check.enableSchedule(false);
-  __kernel->removeSchedule(&_periodic_check);
+  platform.kernel()->removeSchedule(&_periodic_check);
 }
 
 
@@ -130,7 +130,7 @@ int8_t ADCScanner::attached() {
   _periodic_check.alterSchedulePeriod(50);
   _periodic_check.autoClear(false);
   _periodic_check.enableSchedule(true);
-  __kernel->addSchedule(&_periodic_check);
+  platform.kernel()->addSchedule(&_periodic_check);
   return 1;
 }
 

--- a/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
+++ b/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
@@ -191,6 +191,6 @@ int8_t ADCScanner::notify(ManuvrRunnable *active_event) {
       return_value += EventReceiver::notify(active_event);
       break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }

--- a/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
+++ b/ManuvrOS/Drivers/ADCScanner/ADCScanner.cpp
@@ -161,7 +161,7 @@ void ADCScanner::printDebug(StringBuilder *output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ADCScanner::callback_proc(ManuvrRunnable *event) {
+int8_t ADCScanner::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -176,7 +176,7 @@ int8_t ADCScanner::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t ADCScanner::notify(ManuvrRunnable *active_event) {
+int8_t ADCScanner::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/ADCScanner/ADCScanner.h
+++ b/ManuvrOS/Drivers/ADCScanner/ADCScanner.h
@@ -41,8 +41,8 @@ limitations under the License.
 
       /* Overrides from EventReceiver */
       void printDebug(StringBuilder*);
-      int8_t notify(ManuvrRunnable*);
-      int8_t callback_proc(ManuvrRunnable *);
+      int8_t notify(ManuvrMsg*);
+      int8_t callback_proc(ManuvrMsg*);
 
 
     protected:
@@ -53,6 +53,6 @@ limitations under the License.
       int8_t   adc_list[16];
       uint16_t last_sample[16];
       uint16_t threshold[16];
-      ManuvrRunnable _periodic_check;
+      ManuvrMsg _periodic_check;
   };
 #endif

--- a/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
+++ b/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
@@ -409,7 +409,7 @@ int8_t ADP8866::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ADP8866::callback_proc(ManuvrRunnable *event) {
+int8_t ADP8866::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -425,7 +425,7 @@ int8_t ADP8866::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ADP8866::notify(ManuvrRunnable *active_event) {
+int8_t ADP8866::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
+++ b/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
@@ -31,22 +31,16 @@ limitations under the License.
 
 
 const MessageTypeDef adp8866_message_defs[] = {
-  {  MANUVR_MSG_ADP8866_IRQ, 0x0000,  "ADP8866_IRQ",  ManuvrMsg::MSG_ARGS_NONE, NULL },  //
+  {  MANUVR_MSG_ADP8866_IRQ, 0x0000,  "ADP8866_IRQ",  ManuvrMsg::MSG_ARGS_NONE },  //
 
   /*
     For messages that have arguments, we have the option of defining inline lables for each parameter.
     This is advantageous for debugging and writing front-ends. We case-off here to make this choice at
     compile time.
   */
-  #if defined (__ENABLE_MSG_SEMANTICS)
-  {  MANUVR_MSG_ADP8866_CHAN_ENABLED, MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_ENABLED", ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_ADP8866_CHAN_LEVEL,   MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_LEVEL",   ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_ADP8866_ASSIGN_BL,    MSG_FLAG_EXPORTABLE,  "ADP8866_ASSIGN_BL",    ManuvrMsg::MSG_ARGS_NONE, NULL }  //
-  #else
-  {  MANUVR_MSG_ADP8866_CHAN_ENABLED, MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_ENABLED", ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_ADP8866_CHAN_LEVEL,   MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_LEVEL",   ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_ADP8866_ASSIGN_BL,    MSG_FLAG_EXPORTABLE,  "ADP8866_ASSIGN_BL",    ManuvrMsg::MSG_ARGS_NONE, NULL }  //
-  #endif
+  {  MANUVR_MSG_ADP8866_CHAN_ENABLED, MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_ENABLED", ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_ADP8866_CHAN_LEVEL,   MSG_FLAG_EXPORTABLE,  "ADP8866_CHAN_LEVEL",   ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_ADP8866_ASSIGN_BL,    MSG_FLAG_EXPORTABLE,  "ADP8866_ASSIGN_BL",    ManuvrMsg::MSG_ARGS_NONE }  //
 };
 
 ADP8866* ADP8866::INSTANCE = NULL;

--- a/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
+++ b/ManuvrOS/Drivers/ADP8866/ADP8866.cpp
@@ -344,7 +344,7 @@ void ADP8866::operationCompleteCallback(I2CBusOp* completed) {
         temp_reg->unread = false;
         break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 
 
@@ -437,7 +437,7 @@ int8_t ADP8866::notify(ManuvrRunnable *active_event) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -496,7 +496,7 @@ void ADP8866::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  //MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/Drivers/ADP8866/ADP8866.h
+++ b/ManuvrOS/Drivers/ADP8866/ADP8866.h
@@ -121,8 +121,8 @@ class ADP8866 : public EventReceiver, I2CDeviceWithRegisters {
     void printDebug(StringBuilder*);
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/AudioRouter/AudioRouter.cpp
+++ b/ManuvrOS/Drivers/AudioRouter/AudioRouter.cpp
@@ -548,15 +548,17 @@ int8_t AudioRouter::notify(ManuvrRunnable *active_event) {
 
     case VIAM_SONUS_MSG_GROUP_CHANNELS:
     case VIAM_SONUS_MSG_UNGROUP_CHANNELS:
-      local_log.concat("Was passed an event that we should be handling, but are not yet:\n");
-      active_event->printDebug(&local_log);
+      #ifdef __MANUVR_DEBUG
+        local_log.concat("Was passed an event that we should be handling, but are not yet:\n");
+        active_event->printDebug(&local_log);
+      #endif
       break;
 
     default:
       return_value += EventReceiver::notify(active_event);
       break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -628,6 +630,6 @@ void AudioRouter::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/AudioRouter/AudioRouter.cpp
+++ b/ManuvrOS/Drivers/AudioRouter/AudioRouter.cpp
@@ -444,7 +444,7 @@ void AudioRouter::printDebug(StringBuilder *output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t AudioRouter::callback_proc(ManuvrRunnable *event) {
+int8_t AudioRouter::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -459,7 +459,7 @@ int8_t AudioRouter::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t AudioRouter::notify(ManuvrRunnable *active_event) {
+int8_t AudioRouter::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
   uint8_t temp_uint8_0;
   uint8_t temp_uint8_1;
@@ -570,7 +570,7 @@ void AudioRouter::procDirectDebugInstruction(StringBuilder *input) {
 
   char c = *(str);
   StringBuilder parse_mule;
-  ManuvrRunnable* event;
+  ManuvrMsg* event;
 
   switch (c) {
     // AudioRouter debugging cases....
@@ -585,7 +585,7 @@ void AudioRouter::procDirectDebugInstruction(StringBuilder *input) {
       parse_mule.split(" ");
       parse_mule.drop_position(0);
 
-      event = new ManuvrRunnable((c == 'r') ? VIAM_SONUS_MSG_ROUTE : VIAM_SONUS_MSG_UNROUTE);
+      event = new ManuvrMsg((c == 'r') ? VIAM_SONUS_MSG_ROUTE : VIAM_SONUS_MSG_UNROUTE);
       switch (parse_mule.count()) {
         case 2:
           event->addArg((uint8_t) parse_mule.position_as_int(0));
@@ -602,7 +602,7 @@ void AudioRouter::procDirectDebugInstruction(StringBuilder *input) {
       parse_mule.concat(str);
       parse_mule.split(" ");
       parse_mule.drop_position(0);
-      event = new ManuvrRunnable(VIAM_SONUS_MSG_OUTPUT_CHAN_VOL);
+      event = new ManuvrMsg(VIAM_SONUS_MSG_OUTPUT_CHAN_VOL);
       switch (parse_mule.count()) {
         case 2:
           event->addArg((uint8_t) parse_mule.position_as_int(0));

--- a/ManuvrOS/Drivers/AudioRouter/AudioRouter.h
+++ b/ManuvrOS/Drivers/AudioRouter/AudioRouter.h
@@ -115,8 +115,8 @@ class AudioRouter : public EventReceiver {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/ChainForge/ChainForge.h
+++ b/ManuvrOS/Drivers/ChainForge/ChainForge.h
@@ -38,8 +38,8 @@ ChainForge is the optional utility module to cause triggerd and conditional
 //
 //    /* Overrides from EventReceiver */
 //    void printDebug(StringBuilder *);
-//    int8_t notify(ManuvrRunnable*);
-//    int8_t callback_proc(ManuvrRunnable *);
+//    int8_t notify(ManuvrMsg*);
+//    int8_t callback_proc(ManuvrMsg*);
 //
 //
 //  protected:

--- a/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.cpp
+++ b/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.cpp
@@ -118,7 +118,7 @@ int8_t ExampleDriver::notify(ManuvrRunnable *active_event) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -138,6 +138,6 @@ void ExampleDriver::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif

--- a/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.cpp
+++ b/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.cpp
@@ -91,7 +91,7 @@ void ExampleDriver::printDebug(StringBuilder* output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ExampleDriver::callback_proc(ManuvrRunnable *event) {
+int8_t ExampleDriver::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -109,7 +109,7 @@ int8_t ExampleDriver::callback_proc(ManuvrRunnable *event) {
 
 /**
 */
-int8_t ExampleDriver::notify(ManuvrRunnable *active_event) {
+int8_t ExampleDriver::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.h
+++ b/ManuvrOS/Drivers/ExampleDriver/ExampleDriver.h
@@ -38,8 +38,8 @@ class ExampleDriver : public EventReceiver {
     ~ExampleDriver();
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void printDebug(StringBuilder*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);

--- a/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
+++ b/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
@@ -133,7 +133,7 @@ void LightSensor::printDebug(StringBuilder *output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t LightSensor::callback_proc(ManuvrRunnable *event) {
+int8_t LightSensor::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -153,7 +153,7 @@ int8_t LightSensor::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t LightSensor::notify(ManuvrRunnable *active_event) {
+int8_t LightSensor::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
+++ b/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
@@ -47,7 +47,7 @@ LightSensor::LightSensor(int analog_pin) : EventReceiver() {
 
 LightSensor::~LightSensor() {
   _periodic_check.enableSchedule(false);
-  __kernel->removeSchedule(&_periodic_check);
+  platform.kernel()->removeSchedule(&_periodic_check);
 }
 
 
@@ -98,7 +98,7 @@ int8_t LightSensor::attached() {
   _periodic_check.alterSchedulePeriod(501);
   _periodic_check.autoClear(false);
   _periodic_check.enableSchedule(true);
-  __kernel->addSchedule(&_periodic_check);
+  platform.kernel()->addSchedule(&_periodic_check);
 
   return 1;
 }

--- a/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
+++ b/ManuvrOS/Drivers/LightSensor/LightSensor.cpp
@@ -165,6 +165,6 @@ int8_t LightSensor::notify(ManuvrRunnable *active_event) {
       return_value += EventReceiver::notify(active_event);
       break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }

--- a/ManuvrOS/Drivers/LightSensor/LightSensor.h
+++ b/ManuvrOS/Drivers/LightSensor/LightSensor.h
@@ -36,8 +36,8 @@ This is a quick-and-dirty class to support reading a CdS cell from an analog
 
       /* Overrides from EventReceiver */
       void printDebug(StringBuilder*);
-      int8_t notify(ManuvrRunnable*);
-      int8_t callback_proc(ManuvrRunnable *);
+      int8_t notify(ManuvrMsg*);
+      int8_t callback_proc(ManuvrMsg*);
 
 
     protected:
@@ -46,7 +46,7 @@ This is a quick-and-dirty class to support reading a CdS cell from an analog
 
     private:
       int _analog_pin = -1;
-      ManuvrRunnable _periodic_check;
+      ManuvrMsg _periodic_check;
 
       void light_check();
   };

--- a/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
+++ b/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
@@ -697,7 +697,7 @@ int8_t MGC3130::attached() {
   init_runnable->autoClear(true);
   init_runnable->enableSchedule(true);
 
-  __kernel->addSchedule(init_runnable);
+  platform.kernel()->addSchedule(init_runnable);
   return 1;
 }
 

--- a/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
+++ b/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
@@ -33,15 +33,14 @@ This class is a driver for Microchip's MGC3130 e-field gesture sensor. It is mea
 
 
 const MessageTypeDef mgc3130_message_defs[] = {
-  {  MANUVR_MSG_SENSOR_MGC3130            , 0x0000,  "MGC3130",                   ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_SENSOR_MGC3130_INIT       , 0x0000,  "MGC3130_INIT",              ManuvrMsg::MSG_ARGS_NONE, NULL }, //
+  {  MANUVR_MSG_SENSOR_MGC3130            , 0x0000,  "MGC3130",                   ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_SENSOR_MGC3130_INIT       , 0x0000,  "MGC3130_INIT",              ManuvrMsg::MSG_ARGS_NONE }, //
 
   /*
     For messages that have arguments, we have the option of defining inline lables for each parameter.
     This is advantageous for debugging and writing front-ends. We case-off here to make this choice at
     compile time.
   */
-  #if defined (__ENABLE_MSG_SEMANTICS)
   {  MANUVR_MSG_GESTURE_LEGEND            , MSG_FLAG_EXPORTABLE,  "GESTURE_LEGEND",            ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_GESTURE_DEFINITION        , MSG_FLAG_EXPORTABLE,  "GESTURE_DEFINITION",        ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_GESTURE_OBLITERATE        , MSG_FLAG_EXPORTABLE,  "GESTURE_OBLITERATE",        ManuvrMsg::MSG_ARGS_NONE }, //
@@ -51,17 +50,6 @@ const MessageTypeDef mgc3130_message_defs[] = {
   {  MANUVR_MSG_GESTURE_NUANCE            , MSG_FLAG_EXPORTABLE,  "GESTURE_NUANCE",            ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_GESTURE_DISASSERT         , MSG_FLAG_EXPORTABLE,  "GESTURE_DISASSERT",         ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_GESTURE_ONE_SHOT          , MSG_FLAG_EXPORTABLE,  "GESTURE_ONE_SHOT",          ManuvrMsg::MSG_ARGS_NONE }, //
-  #else
-  {  MANUVR_MSG_GESTURE_LEGEND            , MSG_FLAG_EXPORTABLE,  "GESTURE_LEGEND",            ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_DEFINITION        , MSG_FLAG_EXPORTABLE,  "GESTURE_DEFINITION",        ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_OBLITERATE        , MSG_FLAG_EXPORTABLE,  "GESTURE_OBLITERATE",        ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_LINK              , MSG_FLAG_EXPORTABLE,  "GESTURE_LINK",              ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_UNLINK            , MSG_FLAG_EXPORTABLE,  "GESTURE_UNLINK",            ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_RECOGNIZED        , MSG_FLAG_EXPORTABLE,  "GESTURE_RECOGNIZED",        ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_NUANCE            , MSG_FLAG_EXPORTABLE,  "GESTURE_NUANCE",            ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_DISASSERT         , MSG_FLAG_EXPORTABLE,  "GESTURE_DISASSERT",         ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_GESTURE_ONE_SHOT          , MSG_FLAG_EXPORTABLE,  "GESTURE_ONE_SHOT",          ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  #endif
 };
 
 

--- a/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
+++ b/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
@@ -53,7 +53,7 @@ const MessageTypeDef mgc3130_message_defs[] = {
 };
 
 
-ManuvrRunnable _isr_read_event(MANUVR_MSG_SENSOR_MGC3130);
+ManuvrMsg _isr_read_event(MANUVR_MSG_SENSOR_MGC3130);
 volatile int _isr_ts_pin = 0;
 
 
@@ -372,7 +372,7 @@ void MGC3130::printDebug(StringBuilder* output) {
 */
 
 void MGC3130::dispatchGestureEvents() {
-  ManuvrRunnable* event = NULL;
+  ManuvrMsg* event = NULL;
 
   if (isPositionDirty()) {
     // We don't want to spam the Kernel. We need to rate-limit.
@@ -689,7 +689,7 @@ bool MGC3130::operationCallahead(I2CBusOp* op) {
 int8_t MGC3130::attached() {
   EventReceiver::attached();
   init();
-  ManuvrRunnable* init_runnable = Kernel::returnEvent(MANUVR_MSG_SENSOR_MGC3130_INIT);
+  ManuvrMsg* init_runnable = Kernel::returnEvent(MANUVR_MSG_SENSOR_MGC3130_INIT);
 
   init_runnable->specific_target = (EventReceiver*) this;
   init_runnable->alterScheduleRecurrence(0);
@@ -717,7 +717,7 @@ int8_t MGC3130::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t MGC3130::callback_proc(ManuvrRunnable *event) {
+int8_t MGC3130::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -735,7 +735,7 @@ int8_t MGC3130::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t MGC3130::notify(ManuvrRunnable *active_event) {
+int8_t MGC3130::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
+++ b/ManuvrOS/Drivers/MGC3130/MGC3130.cpp
@@ -771,7 +771,7 @@ int8_t MGC3130::notify(ManuvrRunnable *active_event) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -788,6 +788,6 @@ void MGC3130::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/MGC3130/MGC3130.h
+++ b/ManuvrOS/Drivers/MGC3130/MGC3130.h
@@ -81,8 +81,8 @@ class MGC3130 : public I2CDevice, public EventReceiver {
     bool operationCallahead(I2CBusOp* op);
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void procDirectDebugInstruction(StringBuilder *);
     void printDebug(StringBuilder*);
 

--- a/ManuvrOS/Drivers/ManuvrAudio/ManuvrAudio.cpp
+++ b/ManuvrOS/Drivers/ManuvrAudio/ManuvrAudio.cpp
@@ -102,7 +102,7 @@ void ManuvrAudio::printDebug(StringBuilder* output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrAudio::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrAudio::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->eventManagerShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -118,7 +118,7 @@ int8_t ManuvrAudio::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ManuvrAudio::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrAudio::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/ManuvrAudio/ManuvrAudio.h
+++ b/ManuvrOS/Drivers/ManuvrAudio/ManuvrAudio.h
@@ -543,8 +543,8 @@ class ManuvrAudio : public EventReceiver {
     virtual ~ManuvrAudio();
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void procDirectDebugInstruction(StringBuilder *);
     void printDebug(StringBuilder*);
 

--- a/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
+++ b/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
@@ -105,7 +105,7 @@ void ManuvrableGPIO::printDebug(StringBuilder *output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrableGPIO::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrableGPIO::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -120,7 +120,7 @@ int8_t ManuvrableGPIO::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t ManuvrableGPIO::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrableGPIO::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
   uint8_t pin   = 0;
   uint16_t _val = 0;
@@ -163,7 +163,7 @@ int8_t ManuvrableGPIO::notify(ManuvrRunnable *active_event) {
       break;
 
     case MANUVR_MSG_EVENT_ON_INTERRUPT:
-      //int8_t setPinEvent(uint8_t pin, ManuvrRunnable* isr_event);
+      //int8_t setPinEvent(uint8_t pin, ManuvrMsg* isr_event);
       return_value++;
       break;
 

--- a/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
+++ b/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
@@ -24,8 +24,6 @@ The idea here is not to provide any manner of abstraction for GPIO. Our
 
 #include "ManuvrableGPIO.h"
 
-const unsigned char MSG_ARGS_U8_U16[] = {UINT8_FM, UINT16_FM, 0};
-
 
 const MessageTypeDef gpio_message_defs[] = {
   /*
@@ -33,21 +31,12 @@ const MessageTypeDef gpio_message_defs[] = {
     This is advantageous for debugging and writing front-ends. We case-off here to make this choice at
     compile time.
   */
-  #if defined (__ENABLE_MSG_SEMANTICS)
   {  MANUVR_MSG_GPIO_LEGEND       , MSG_FLAG_EXPORTABLE,  "GPIO_LEGEND",         ManuvrMsg::MSG_ARGS_NONE }, //
-  {  MANUVR_MSG_DIGITAL_READ      , MSG_FLAG_EXPORTABLE,  "DIGITAL_READ",        MSG_ARGS_U8_U16 }, //
-  {  MANUVR_MSG_DIGITAL_WRITE     , MSG_FLAG_EXPORTABLE,  "DIGITAL_WRITE",       MSG_ARGS_U8_U16 }, //
-  {  MANUVR_MSG_ANALOG_READ       , MSG_FLAG_EXPORTABLE,  "ANALOG_READ",         MSG_ARGS_U8_U16 }, //
-  {  MANUVR_MSG_ANALOG_WRITE      , MSG_FLAG_EXPORTABLE,  "ANALOG_WRITE",        MSG_ARGS_U8_U16 }, //
+  {  MANUVR_MSG_DIGITAL_READ      , MSG_FLAG_EXPORTABLE,  "DIGITAL_READ",        ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_DIGITAL_WRITE     , MSG_FLAG_EXPORTABLE,  "DIGITAL_WRITE",       ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_ANALOG_READ       , MSG_FLAG_EXPORTABLE,  "ANALOG_READ",         ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_ANALOG_WRITE      , MSG_FLAG_EXPORTABLE,  "ANALOG_WRITE",        ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_EVENT_ON_INTERRUPT, MSG_FLAG_EXPORTABLE,  "EVENT_ON_INTERRUPT",  ManuvrMsg::MSG_ARGS_NONE }, //
-  #else
-  {  MANUVR_MSG_GPIO_LEGEND       , MSG_FLAG_EXPORTABLE,  "GPIO_LEGEND",         ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  {  MANUVR_MSG_DIGITAL_READ      , MSG_FLAG_EXPORTABLE,  "DIGITAL_READ",        MSG_ARGS_U8_U16, NULL }, //
-  {  MANUVR_MSG_DIGITAL_WRITE     , MSG_FLAG_EXPORTABLE,  "DIGITAL_WRITE",       MSG_ARGS_U8_U16, NULL }, //
-  {  MANUVR_MSG_ANALOG_READ       , MSG_FLAG_EXPORTABLE,  "ANALOG_READ",         MSG_ARGS_U8_U16, NULL }, //
-  {  MANUVR_MSG_ANALOG_WRITE      , MSG_FLAG_EXPORTABLE,  "ANALOG_WRITE",        MSG_ARGS_U8_U16, NULL }, //
-  {  MANUVR_MSG_EVENT_ON_INTERRUPT, MSG_FLAG_EXPORTABLE,  "EVENT_ON_INTERRUPT",  ManuvrMsg::MSG_ARGS_NONE, NULL }, //
-  #endif
 };
 
 

--- a/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
+++ b/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.cpp
@@ -175,7 +175,7 @@ int8_t ManuvrableGPIO::notify(ManuvrRunnable *active_event) {
       return_value += EventReceiver::notify(active_event);
       break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -206,6 +206,6 @@ void ManuvrableGPIO::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.h
+++ b/ManuvrOS/Drivers/ManuvrableGPIO/ManuvrableGPIO.h
@@ -39,8 +39,8 @@ The idea here is not to provide any manner of abstraction for GPIO. Our
 
       /* Overrides from EventReceiver */
       void printDebug(StringBuilder*);
-      int8_t notify(ManuvrRunnable*);
-      int8_t callback_proc(ManuvrRunnable *);
+      int8_t notify(ManuvrMsg*);
+      int8_t callback_proc(ManuvrMsg*);
       #if defined(MANUVR_CONSOLE_SUPPORT)
         void procDirectDebugInstruction(StringBuilder*);
       #endif  //MANUVR_CONSOLE_SUPPORT
@@ -51,7 +51,7 @@ The idea here is not to provide any manner of abstraction for GPIO. Our
 
 
     private:
-      ManuvrRunnable _gpio_notice;
+      ManuvrMsg _gpio_notice;
   };
 
 #endif // MANUVRABLE_GPIO_H

--- a/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.cpp
+++ b/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.cpp
@@ -443,7 +443,7 @@ int8_t ManuvrableNeoPixel::notify(ManuvrRunnable *active_event) {
       return_value += EventReceiver::notify(active_event);
       break;
   }
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -501,6 +501,6 @@ void ManuvrableNeoPixel::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.cpp
+++ b/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.cpp
@@ -361,7 +361,7 @@ void ManuvrableNeoPixel::printDebug(StringBuilder *output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrableNeoPixel::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrableNeoPixel::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -377,7 +377,7 @@ int8_t ManuvrableNeoPixel::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ManuvrableNeoPixel::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrableNeoPixel::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.h
+++ b/ManuvrOS/Drivers/ManuvrableNeoPixel/ManuvrableNeoPixel.h
@@ -66,8 +66,8 @@ class ManuvrableNeoPixel : public EventReceiver {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.cpp
+++ b/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.cpp
@@ -442,7 +442,7 @@ int8_t LDS8160::notify(ManuvrRunnable *active_event) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
   return return_value;
 }
 
@@ -545,7 +545,7 @@ void LDS8160::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 
 #endif  // MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.cpp
+++ b/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.cpp
@@ -237,7 +237,7 @@ int8_t LDS8160::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t LDS8160::callback_proc(ManuvrRunnable *event) {
+int8_t LDS8160::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->KernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -253,7 +253,7 @@ int8_t LDS8160::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t LDS8160::notify(ManuvrRunnable *active_event) {
+int8_t LDS8160::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {
@@ -450,7 +450,7 @@ int8_t LDS8160::notify(ManuvrRunnable *active_event) {
 #if defined(MANUVR_CONSOLE_SUPPORT)
 void LDS8160::procDirectDebugInstruction(StringBuilder *input) {
   char* str = input->position(0);
-  ManuvrRunnable *event = NULL;  // Pitching events is a common thing in this fxn...
+  ManuvrMsg *event = NULL;  // Pitching events is a common thing in this fxn...
 
   uint8_t temp_byte = 0;
   if (*(str) != 0) {

--- a/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.h
+++ b/ManuvrOS/Drivers/PMIC/LDS8160/LDS8160.h
@@ -74,8 +74,8 @@ class LDS8160 : public I2CDeviceWithRegisters, public EventReceiver {
     void printDebug(StringBuilder*);
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void procDirectDebugInstruction(StringBuilder *);
 
     /* Direct channel manipulation. */

--- a/ManuvrOS/Drivers/TestDriver/TestDriver.cpp
+++ b/ManuvrOS/Drivers/TestDriver/TestDriver.cpp
@@ -85,7 +85,7 @@ void TestDriver::printDebug(StringBuilder* output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t TestDriver::callback_proc(ManuvrRunnable *event) {
+int8_t TestDriver::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -101,7 +101,7 @@ int8_t TestDriver::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t TestDriver::notify(ManuvrRunnable *active_event) {
+int8_t TestDriver::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/TestDriver/TestDriver.h
+++ b/ManuvrOS/Drivers/TestDriver/TestDriver.h
@@ -37,8 +37,8 @@ class TestDriver : public EventReceiver {
     ~TestDriver();
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void printDebug(StringBuilder*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);

--- a/ManuvrOS/Drivers/i2c-adapter/I2CBusOp.cpp
+++ b/ManuvrOS/Drivers/i2c-adapter/I2CBusOp.cpp
@@ -136,7 +136,7 @@ int8_t I2CBusOp::abort(XferFault er) {
 */
 void I2CBusOp::markComplete() {
 	xfer_state = XferState::COMPLETE;
-	ManuvrRunnable* q_rdy = Kernel::returnEvent(MANUVR_MSG_I2C_QUEUE_READY);
+	ManuvrMsg* q_rdy = Kernel::returnEvent(MANUVR_MSG_I2C_QUEUE_READY);
 	q_rdy->specific_target = device;
   Kernel::isrRaiseEvent(q_rdy);   // Raise an event
 }

--- a/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
+++ b/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
@@ -953,6 +953,6 @@ void I2CAdapter::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  //MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
+++ b/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
@@ -68,6 +68,7 @@ This file is the tortured result of growing pains since the beginning of
   // TODO: Migrate case-off code to platform directory.
 #endif
 
+#include <Platform/Platform.h>
 
 extern "C" {
   volatile I2CAdapter* i2c = NULL;
@@ -351,7 +352,7 @@ int8_t I2CAdapter::attached() {
   if (busOnline()) {
     advance_work_queue();
   }
-  __kernel->addSchedule(&_periodic_i2c_debug);
+  platform.kernel()->addSchedule(&_periodic_i2c_debug);
   return 1;
 }
 

--- a/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
+++ b/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.cpp
@@ -371,7 +371,7 @@ int8_t I2CAdapter::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t I2CAdapter::callback_proc(ManuvrRunnable *event) {
+int8_t I2CAdapter::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -387,7 +387,7 @@ int8_t I2CAdapter::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t I2CAdapter::notify(ManuvrRunnable *active_event) {
+int8_t I2CAdapter::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.h
+++ b/ManuvrOS/Drivers/i2c-adapter/i2c-adapter.h
@@ -149,7 +149,7 @@ This file is the tortured result of growing pains since the beginning of
     private:
       int8_t init_dma();
 
-      static ManuvrRunnable event_queue_ready;
+      static ManuvrMsg event_queue_ready;
   };
 
 
@@ -180,8 +180,8 @@ This file is the tortured result of growing pains since the beginning of
       void printDevs(StringBuilder*, uint8_t dev_num);
 
       /* Overrides from EventReceiver */
-      int8_t notify(ManuvrRunnable*);
-      int8_t callback_proc(ManuvrRunnable*);
+      int8_t notify(ManuvrMsg*);
+      int8_t callback_proc(ManuvrMsg*);
       #if defined(MANUVR_CONSOLE_SUPPORT)
         void procDirectDebugInstruction(StringBuilder*);
       #endif  //MANUVR_CONSOLE_SUPPORT
@@ -209,7 +209,7 @@ This file is the tortured result of growing pains since the beginning of
     private:
       LinkedList<I2CBusOp*>  work_queue;  // A work queue to keep transactions in order.
       LinkedList<I2CDevice*> dev_list;    // A list of active slaves on this bus.
-      ManuvrRunnable _periodic_i2c_debug;
+      ManuvrMsg _periodic_i2c_debug;
 
       int8_t ping_map[128];
       int8_t last_used_bus_addr;

--- a/ManuvrOS/EnumeratedTypeCodes.h
+++ b/ManuvrOS/EnumeratedTypeCodes.h
@@ -115,7 +115,7 @@ typedef struct typecode_def_t {
 
 #define SYS_EVENTRECEIVER_FM    0xE0 // A pointer to an EventReceiver.
 #define SYS_MANUVR_XPORT_FM     0xE1 // A pointer to a ManuvrXport.
-#define SYS_RUNNABLE_PTR_FM     0xE2 // A pointer to a ManuvrRunnable.
+#define SYS_MANUVRMSG_FM     0xE2 // A pointer to a ManuvrMsg.
 
 #define SYS_FXN_PTR_FM          0xEC // FxnPointer
 #define SYS_THREAD_FXN_PTR_FM   0xED // ThreadFxnPtr

--- a/ManuvrOS/EnumeratedTypeCodes.h
+++ b/ManuvrOS/EnumeratedTypeCodes.h
@@ -34,6 +34,7 @@ limitations under the License.
 
 class BufferPipe;
 class Argument;
+class ManuvrMsg;
 
 /*******************************************************************************
 * Function-pointer definitions.                                                *
@@ -48,13 +49,15 @@ typedef void* (*ThreadFxnPtr)(void*);
 /* Takes an Argument list and returns a code. */
 typedef int (*ArgumentFxnPtr)(Argument*);
 
+typedef int (*listenerFxnPtr)(ManuvrMsg*);
+
 /*
 * Used in Async BufferPipes to move data in idle-time.
 * if direction is negative, buffer will flush toward counterparty.
 * if direction is positive, buffer will flush toward application.
 * if direction is zero, buffer will purge with no transfer.
 */
-typedef void  (*PipeIOCallback)(BufferPipe*, int direction);
+typedef void (*PipeIOCallback)(BufferPipe*, int direction);
 
 /**
 * This is the structure with which we define types. These types are used by a variety of
@@ -115,7 +118,7 @@ typedef struct typecode_def_t {
 
 #define SYS_EVENTRECEIVER_FM    0xE0 // A pointer to an EventReceiver.
 #define SYS_MANUVR_XPORT_FM     0xE1 // A pointer to a ManuvrXport.
-#define SYS_MANUVRMSG_FM     0xE2 // A pointer to a ManuvrMsg.
+#define SYS_MANUVRMSG_FM        0xE2 // A pointer to a ManuvrMsg.
 
 #define SYS_FXN_PTR_FM          0xEC // FxnPointer
 #define SYS_THREAD_FXN_PTR_FM   0xED // ThreadFxnPtr

--- a/ManuvrOS/EventReceiver.cpp
+++ b/ManuvrOS/EventReceiver.cpp
@@ -80,7 +80,7 @@ int8_t EventReceiver::setVerbosity(int8_t nu_verbosity) {
 * @param   active_event  An event bearing the code for "set verbosity".
 * @return  -1 on failure, and 0 on no change, and 1 on success.
 */
-int8_t EventReceiver::setVerbosity(ManuvrRunnable* active_event) {
+int8_t EventReceiver::setVerbosity(ManuvrMsg* active_event) {
   if (nullptr == active_event) return -1;
   if (MANUVR_MSG_SYS_LOG_VERBOSITY != active_event->eventCode()) return -1;
   switch (active_event->argCount()) {
@@ -147,7 +147,7 @@ void EventReceiver::procDirectDebugInstruction(StringBuilder *input) {
 * This is a convenience method for posting an event when we want a callback. If there is not
 *   already an originator specified, add ourselves as the originator.
 */
-int8_t EventReceiver::raiseEvent(ManuvrRunnable* event) {
+int8_t EventReceiver::raiseEvent(ManuvrMsg* event) {
   if (event != nullptr) {
     event->setOriginator(this);
     return Kernel::staticRaiseEvent(event);
@@ -233,7 +233,7 @@ int8_t EventReceiver::erConfigure(Argument*) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t EventReceiver::callback_proc(ManuvrRunnable *event) {
+int8_t EventReceiver::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -259,7 +259,7 @@ int8_t EventReceiver::callback_proc(ManuvrRunnable *event) {
 * @param active_event is the event being broadcast.
 * @return the number of actions taken on this event, or -1 on failure.
 */
-int8_t EventReceiver::notify(ManuvrRunnable *active_event) {
+int8_t EventReceiver::notify(ManuvrMsg* active_event) {
   if (active_event) {
     switch (active_event->eventCode()) {
       case MANUVR_MSG_SYS_LOG_VERBOSITY:

--- a/ManuvrOS/EventReceiver.cpp
+++ b/ManuvrOS/EventReceiver.cpp
@@ -182,9 +182,9 @@ void EventReceiver::printDebug() {
 */
 void EventReceiver::printDebug(StringBuilder *output) {
   #if defined(__BUILD_HAS_THREADS)
-  output->concatf("\n==< %s %s  Thread %d >=======\n", getReceiverName(), (erAttached() ? "   (UNATTACHED) " : ""), _thread_id);
+  output->concatf("\n==< %s %s  Thread %d >=======\n", getReceiverName(), (erAttached() ? "" : "   (UNATTACHED) "), _thread_id);
   #else
-  output->concatf("\n==< %s %s>======================\n", getReceiverName(), (erAttached() ? "   (UNATTACHED) " : ""));
+  output->concatf("\n==< %s %s>======================\n", getReceiverName(), (erAttached() ? "" : "   (UNATTACHED) "));
   #endif
 }
 

--- a/ManuvrOS/EventReceiver.cpp
+++ b/ManuvrOS/EventReceiver.cpp
@@ -23,24 +23,14 @@ limitations under the License.
 #include <Platform/Platform.h>
 
 
-EventReceiver::EventReceiver() {
-  _receiver_name = "EventReceiver";
-  __kernel       = nullptr;
-  _class_state   = (DEFAULT_CLASS_VERBOSITY & MANUVR_ER_FLAG_VERBOSITY_MASK);
-  _extnd_state   = 0;
-  #if defined(__BUILD_HAS_THREADS)
-    _thread_id = -1;
-  #endif
-}
+EventReceiver::EventReceiver() {}
 
 
 EventReceiver::~EventReceiver() {
-  if (nullptr != __kernel) {
-    __kernel->unsubscribe(this);
-  }
+  platform.kernel()->unsubscribe(this);
   #if defined(__BUILD_HAS_THREADS)
-    if (_thread_id > -1) {
-      // TODO: Clean up any threads we may have fired up.
+    if (_thread_id > 0) {
+      deleteThread(&_thread_id);
     }
   #endif
   Kernel::log(&local_log);  // Clears the local_log.
@@ -210,7 +200,6 @@ void EventReceiver::printDebug(StringBuilder *output) {
 */
 int8_t EventReceiver::attached() {
   if (!erAttached()) {
-    __kernel = platform.kernel();
     _mark_attached();
     return 1;
   }

--- a/ManuvrOS/EventReceiver.h
+++ b/ManuvrOS/EventReceiver.h
@@ -68,7 +68,7 @@ Lifecycle:
         *   zero for no action taken, and non-zero if the event needs to be re-evaluated
         *   before being passed on to the next subscriber.
         */
-        virtual int8_t notify(ManuvrRunnable*);
+        virtual int8_t notify(ManuvrMsg*);
 
         /*
         * These have no reason to be here other than to enforce some discipline while
@@ -83,10 +83,10 @@ Lifecycle:
         #endif
 
         /* These are intended to be overridden. */
-        virtual int8_t callback_proc(ManuvrRunnable *);
+        virtual int8_t callback_proc(ManuvrMsg*);
 
         /* Raises an event, marking us as the return callback. */
-        int8_t raiseEvent(ManuvrRunnable* event);
+        int8_t raiseEvent(ManuvrMsg* event);
 
         inline const char* getReceiverName() {   return _receiver_name;  }
 
@@ -166,7 +166,7 @@ Lifecycle:
         uint8_t     _extnd_state   = 0;  // This is here for use by the extending class.
         const char* _receiver_name = "EventReceiver";
 
-        int8_t setVerbosity(ManuvrRunnable*);  // Private because it should be set with an Event.
+        int8_t setVerbosity(ManuvrMsg*);  // Private because it should be set with an Event.
     };
   }
 

--- a/ManuvrOS/EventReceiver.h
+++ b/ManuvrOS/EventReceiver.h
@@ -134,7 +134,12 @@ Lifecycle:
 
 
       protected:
-        Kernel* __kernel;
+        #if defined(__BUILD_HAS_THREADS)
+          // In threaded environments, we allow resources to enable their own threading
+          //   if needed.
+          unsigned long _thread_id  = 0;
+        #endif
+
         StringBuilder local_log;
 
         EventReceiver();
@@ -157,15 +162,9 @@ Lifecycle:
 
 
       private:
-        uint8_t _class_state;
-        uint8_t _extnd_state;  // This is here for use by the extending class.
-        const char* _receiver_name;
-
-        #if defined(__BUILD_HAS_THREADS)
-          // In threaded environments, we allow resources to enable their own threading
-          //   if needed.
-          int _thread_id  = -1;
-        #endif
+        uint8_t     _class_state   = (DEFAULT_CLASS_VERBOSITY & MANUVR_ER_FLAG_VERBOSITY_MASK);
+        uint8_t     _extnd_state   = 0;  // This is here for use by the extending class.
+        const char* _receiver_name = "EventReceiver";
 
         int8_t setVerbosity(ManuvrRunnable*);  // Private because it should be set with an Event.
     };

--- a/ManuvrOS/Frameworks/OIC/ManuvrOIC.cpp
+++ b/ManuvrOS/Frameworks/OIC/ManuvrOIC.cpp
@@ -274,8 +274,8 @@ ManuvrOIC::ManuvrOIC(Argument* root_config) : ManuvrOIC() {
 * Unlike many of the other EventReceivers, THIS one needs to be able to be torn down.
 */
 ManuvrOIC::~ManuvrOIC() {
-  __kernel->removeSchedule(&_discovery_ping);
-  __kernel->removeSchedule(&_discovery_timeout);
+  platform.kernel()->removeSchedule(&_discovery_ping);
+  platform.kernel()->removeSchedule(&_discovery_timeout);
   #if defined(__BUILD_HAS_THREADS)
     #if defined(__MACH__) && defined(__APPLE__)
       if (_thread_id > 0) {
@@ -362,7 +362,7 @@ int8_t ManuvrOIC::attached() {
   _discovery_ping.isManaged(true);
   _discovery_ping.alterSchedule(120000, -1, false, issue_requests_hook);
   _discovery_ping.enableSchedule(false);
-  __kernel->addSchedule(&_discovery_ping);
+  platform.kernel()->addSchedule(&_discovery_ping);
 
   _discovery_timeout.repurpose(MANUVR_MSG_OIC_DISCOVER_OFF, (EventReceiver*) this);
   _discovery_timeout.isManaged(true);
@@ -374,7 +374,7 @@ int8_t ManuvrOIC::attached() {
   _discovery_timeout.alterSchedulePeriod(30000);
   _discovery_timeout.autoClear(false);
   _discovery_timeout.enableSchedule(false);
-  __kernel->addSchedule(&_discovery_timeout);
+  platform.kernel()->addSchedule(&_discovery_timeout);
 
 
   oc_handler_t handler;

--- a/ManuvrOS/Frameworks/OIC/ManuvrOIC.cpp
+++ b/ManuvrOS/Frameworks/OIC/ManuvrOIC.cpp
@@ -183,7 +183,7 @@ oc_discovery_flags_t discovery(const char *di, const char *uri,
               oc_string_array_t types, oc_interface_mask_t interfaces,
               oc_server_handle_t* server) {
   unsigned int i;
-  ManuvrRunnable* disc_ev = Kernel::returnEvent(MANUVR_MSG_OIC_DISCOVERY);
+  ManuvrMsg* disc_ev = Kernel::returnEvent(MANUVR_MSG_OIC_DISCOVERY);
 
   if (server->endpoint.flags & 0x10) {  // TODO: Should use their namespace.
     disc_ev->addArg((uint8_t) 1)->setKey("secure");
@@ -451,7 +451,7 @@ int8_t ManuvrOIC::erConfigure(Argument* opts) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrOIC::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrOIC::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -466,7 +466,7 @@ int8_t ManuvrOIC::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t ManuvrOIC::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrOIC::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Frameworks/OIC/ManuvrOIC.h
+++ b/ManuvrOS/Frameworks/OIC/ManuvrOIC.h
@@ -58,8 +58,8 @@ class ManuvrOIC : public EventReceiver {
     /* Overrides from EventReceiver */
     void procDirectDebugInstruction(StringBuilder*);
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable*);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     int8_t erConfigure(Argument*);
 
     int8_t makeDiscoverable(bool);
@@ -88,8 +88,8 @@ class ManuvrOIC : public EventReceiver {
 
   private:
     /* Scheduled callbacks and events precipitataed from the worker thread.*/
-    ManuvrRunnable _discovery_timeout;
-    ManuvrRunnable _discovery_ping;
+    ManuvrMsg _discovery_timeout;
+    ManuvrMsg _discovery_ping;
 
     /* This maps URIs to resources. */
     std::map<const char*, listenerFxnPtr> _uri_map;

--- a/ManuvrOS/Frameworks/OIC/ManuvrOIC.h
+++ b/ManuvrOS/Frameworks/OIC/ManuvrOIC.h
@@ -87,11 +87,6 @@ class ManuvrOIC : public EventReceiver {
 
 
   private:
-    #if defined(__BUILD_HAS_THREADS)
-      // If we have a concept of threads...
-      unsigned long _thread_id = 0;
-    #endif
-
     /* Scheduled callbacks and events precipitataed from the worker thread.*/
     ManuvrRunnable _discovery_timeout;
     ManuvrRunnable _discovery_ping;

--- a/ManuvrOS/Kernel.cpp
+++ b/ManuvrOS/Kernel.cpp
@@ -115,7 +115,7 @@ const MessageTypeDef ManuvrMsg::message_defs[] = {
   {  MANUVR_MSG_XPORT_QUEUE_RDY,    0x0000,  "XPORT_Q"            , ManuvrMsg::MSG_ARGS_NONE }, //
   {  MANUVR_MSG_XPORT_CB_QUEUE_RDY, 0x0000,  "XPORT_CB_Q"         , ManuvrMsg::MSG_ARGS_NONE }, //
 
-  #if defined (__MANUVR_FREERTOS) | defined (__MANUVR_LINUX)
+  #if defined (MANUVR_OPENINTERCONNECT)
   {  MANUVR_MSG_OIC_READY            , 0x0000,  "OIC_READY"        , ManuvrMsg::MSG_ARGS_NONE },  //
   {  MANUVR_MSG_OIC_REG_RESOURCES    , 0x0000,  "OIC_REG_RESRCS"   , ManuvrMsg::MSG_ARGS_NONE },  //
   {  MANUVR_MSG_OIC_DISCOVERY        , 0x0000,  "OIC_DISCOVERY"    , ManuvrMsg::MSG_ARGS_NONE },  //
@@ -123,17 +123,12 @@ const MessageTypeDef ManuvrMsg::message_defs[] = {
   {  MANUVR_MSG_OIC_DISCOVER_PING    , 0x0000,  "OIC_PING"         , ManuvrMsg::MSG_ARGS_NONE },  //
   #endif
 
-  #if defined (__MANUVR_FREERTOS) | defined (__MANUVR_LINUX)
+  #if defined (__BUILD_HAS_THREADS)
     // These are messages that are only present under some sort of threading model. They are meant
     //   to faciliate task hand-off, IPC, and concurrency protection.
     {  MANUVR_MSG_CREATED_THREAD_ID,    0x0000,              "CREATED_THREAD_ID",     ManuvrMsg::MSG_ARGS_NONE },
     {  MANUVR_MSG_DESTROYED_THREAD_ID,  0x0000,              "DESTROYED_THREAD_ID",   ManuvrMsg::MSG_ARGS_NONE },
     {  MANUVR_MSG_UNBLOCK_THREAD,       0x0000,              "UNBLOCK_THREAD",        ManuvrMsg::MSG_ARGS_NONE },
-    #if defined (__MANUVR_FREERTOS)
-    #endif
-
-    #if defined (__MANUVR_LINUX)
-    #endif
   #endif
 
   /*
@@ -141,17 +136,10 @@ const MessageTypeDef ManuvrMsg::message_defs[] = {
     This is advantageous for debugging and writing front-ends. We case-off here to make this choice at
     compile time.
   */
-  #if defined (__ENABLE_MSG_SEMANTICS)
-  {  MANUVR_MSG_USER_DEBUG_INPUT     , MSG_FLAG_EXPORTABLE,               "USER_DEBUG_INPUT"     , ManuvrMsg::MSG_ARGS_NONE, "Command\0\0" }, //
-  {  MANUVR_MSG_SYS_ISSUE_LOG_ITEM   , MSG_FLAG_EXPORTABLE,               "SYS_ISSUE_LOG_ITEM"   , ManuvrMsg::MSG_ARGS_NONE, "Body\0\0" }, // Classes emit this to get their log data saved/sent.
-  {  MANUVR_MSG_SYS_POWER_MODE       , MSG_FLAG_EXPORTABLE,               "SYS_POWER_MODE"       , ManuvrMsg::MSG_ARGS_NONE, "Power Mode\0\0" }, //
-  {  MANUVR_MSG_SYS_LOG_VERBOSITY    , MSG_FLAG_EXPORTABLE,               "SYS_LOG_VERBOSITY"    , ManuvrMsg::MSG_ARGS_NONE, "Level\0\0"      },   // This tells client classes to adjust their log verbosity.
-  #else
-  {  MANUVR_MSG_USER_DEBUG_INPUT     , MSG_FLAG_EXPORTABLE,               "USER_DEBUG_INPUT"     , ManuvrMsg::MSG_ARGS_NONE, nullptr }, //
-  {  MANUVR_MSG_SYS_ISSUE_LOG_ITEM   , MSG_FLAG_EXPORTABLE,               "SYS_ISSUE_LOG_ITEM"   , ManuvrMsg::MSG_ARGS_NONE, nullptr }, // Classes emit this to get their log data saved/sent.
-  {  MANUVR_MSG_SYS_POWER_MODE       , MSG_FLAG_EXPORTABLE,               "SYS_POWER_MODE"       , ManuvrMsg::MSG_ARGS_NONE, nullptr }, //
-  {  MANUVR_MSG_SYS_LOG_VERBOSITY    , MSG_FLAG_EXPORTABLE,               "SYS_LOG_VERBOSITY"    , ManuvrMsg::MSG_ARGS_NONE, nullptr },   // This tells client classes to adjust their log verbosity.
-  #endif
+  {  MANUVR_MSG_USER_DEBUG_INPUT     , MSG_FLAG_EXPORTABLE,               "USER_DEBUG_INPUT"     , ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_SYS_ISSUE_LOG_ITEM   , MSG_FLAG_EXPORTABLE,               "SYS_ISSUE_LOG_ITEM"   , ManuvrMsg::MSG_ARGS_NONE }, // Classes emit this to get their log data saved/sent.
+  {  MANUVR_MSG_SYS_POWER_MODE       , MSG_FLAG_EXPORTABLE,               "SYS_POWER_MODE"       , ManuvrMsg::MSG_ARGS_NONE }, //
+  {  MANUVR_MSG_SYS_LOG_VERBOSITY    , MSG_FLAG_EXPORTABLE,               "SYS_LOG_VERBOSITY"    , ManuvrMsg::MSG_ARGS_NONE },   // This tells client classes to adjust their log verbosity.
 };
 
 

--- a/ManuvrOS/Kernel.cpp
+++ b/ManuvrOS/Kernel.cpp
@@ -173,7 +173,6 @@ void Kernel::nextTick(BufferPipe* p) {
 Kernel::Kernel() : EventReceiver() {
   setReceiverName("Kernel");
   INSTANCE             = this;  // For singleton reference. TODO: Will not parallelize.
-  __kernel             = this;  // We extend EventReceiver. So we populate this.
 
   current_event        = nullptr;
   max_queue_depth      = 0;

--- a/ManuvrOS/Kernel.cpp
+++ b/ManuvrOS/Kernel.cpp
@@ -622,7 +622,7 @@ int8_t Kernel::procCallAheads(ManuvrRunnable *active_runnable) {
 int8_t Kernel::procCallBacks(ManuvrRunnable *active_runnable) {
   int8_t return_value = 0;
   PriorityQueue<listenerFxnPtr> *cb_queue = cb_listeners[active_runnable->eventCode()];
-  if (nullptr != cb_queue) {
+  if (cb_queue) {
     listenerFxnPtr current_fxn;
     for (int i = 0; i < cb_queue->size(); i++) {
       current_fxn = cb_queue->recycle();  // TODO: This is ugly for many reasons.

--- a/ManuvrOS/Kernel.h
+++ b/ManuvrOS/Kernel.h
@@ -55,19 +55,8 @@ limitations under the License.
 
 
 
-  #if defined(MANUVR_CONSOLE_SUPPORT) || defined(__MANUVR_DEBUG)
-    #ifdef __MANUVR_DEBUG
-      #define DEFAULT_CLASS_VERBOSITY    6
-    #else
-      #define DEFAULT_CLASS_VERBOSITY    4
-    #endif
-  #else
-    #define DEFAULT_CLASS_VERBOSITY      0
-  #endif
-
-
   #ifdef __cplusplus
-   extern "C" {
+  extern "C" {
   #endif
 
   typedef int (*listenerFxnPtr) (ManuvrRunnable*);

--- a/ManuvrOS/ManuvrMsg/ManuvrMsg.cpp
+++ b/ManuvrOS/ManuvrMsg/ManuvrMsg.cpp
@@ -827,7 +827,7 @@ void ManuvrMsg::printDebug(StringBuilder *output) {
 
 
 /*******************************************************************************
-* Functions dealing with profiling this particular Runnable.                   *
+* Functions dealing with profiling this particular Msg.                   *
 *******************************************************************************/
 #if defined(__MANUVR_EVENT_PROFILER)
 
@@ -862,7 +862,7 @@ void ManuvrMsg::profilingEnabled(bool enabled) {
 
 
 /**
-* Destroys whatever profiling data might be stored in this Runnable.
+* Destroys whatever profiling data might be stored in this Msg.
 */
 void ManuvrMsg::clearProfilingData() {
   if (prof_data) {

--- a/ManuvrOS/ManuvrMsg/ManuvrMsg.h
+++ b/ManuvrOS/ManuvrMsg/ManuvrMsg.h
@@ -59,7 +59,6 @@ typedef struct msg_defin_t {
     uint16_t              msg_type_flags; // Optional flags to describe nuances of this message type.
     const char*           debug_label;    // This is a pointer to a const that represents this message code as a string.
     const unsigned char*  arg_modes;      // For messages that have arguments, this defines their possible types.
-    const char*           arg_semantics;  // For messages that have arguments, this defines their semantics.
 } MessageTypeDef;
 
 
@@ -389,9 +388,6 @@ class ManuvrMsg {
 
 
     static int8_t getMsgLegend(StringBuilder *output);
-    #if defined (__ENABLE_MSG_SEMANTICS)
-    static int8_t getMsgSemantics(MessageTypeDef*, StringBuilder *output);
-    #endif
 
     static const MessageTypeDef* lookupMsgDefByCode(uint16_t msg_code);
     static const MessageTypeDef* lookupMsgDefByLabel(char* label);

--- a/ManuvrOS/ManuvrMsg/ManuvrMsg.h
+++ b/ManuvrOS/ManuvrMsg/ManuvrMsg.h
@@ -92,7 +92,7 @@ typedef struct msg_defin_t {
 class ManuvrMsg {
   public:
     EventReceiver*  specific_target = nullptr;  // If the runnable is meant for a single class, put a pointer to it here.
-    int32_t priority = EVENT_PRIORITY_DEFAULT;  // Set the default priority for this Runnable
+    int32_t priority = EVENT_PRIORITY_DEFAULT;  // Set the default priority for this Msg
 
     ManuvrMsg();
     ManuvrMsg(uint16_t code);
@@ -234,7 +234,7 @@ class ManuvrMsg {
     inline int8_t getArgAs(BufferPipe **trg_buf) {                    return getArgAs(0, (void*) trg_buf);  }
     inline int8_t getArgAs(EventReceiver **trg_buf) {                 return getArgAs(0, (void*) trg_buf);  }
     inline int8_t getArgAs(ManuvrXport **trg_buf) {                   return getArgAs(0, (void*) trg_buf);  }
-    inline int8_t getArgAs(ManuvrMsg **trg_buf) {                return getArgAs(0, (void*) trg_buf);  }
+    inline int8_t getArgAs(ManuvrMsg* *trg_buf) {                return getArgAs(0, (void*) trg_buf);  }
 
     inline int8_t getArgAs(uint8_t idx, Vector3f  **trg_buf) {        return getArgAs(idx, (void*) trg_buf);  }
     inline int8_t getArgAs(uint8_t idx, Vector3ui16  **trg_buf) {     return getArgAs(idx, (void*) trg_buf);  }
@@ -435,7 +435,5 @@ class ManuvrMsg {
     // Where runtime-loaded message defs go.
     static std::map<uint16_t, const MessageTypeDef*> message_defs_extended;
 };
-
-typedef ManuvrMsg ManuvrRunnable;  // TODO: Only here until class merger is finished.
 
 #endif

--- a/ManuvrOS/Platform/AppleOSX/AppleOSX.h
+++ b/ManuvrOS/Platform/AppleOSX/AppleOSX.h
@@ -43,6 +43,7 @@ This file is meant to contain a set of common functions that are
   #error Presently, only El Capitan and above are supported.
 #endif
 
+#define __MANUVR_APPLE
 
 /* Used to build an Argument chain from parameters passed to main(). */
 Argument* parseFromArgCV(int argc, const char* argv[]);

--- a/ManuvrOS/Platform/Arduino/Arduino.cpp
+++ b/ManuvrOS/Platform/Arduino/Arduino.cpp
@@ -172,7 +172,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrRunnable* isr_event) {
+int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrMsg* isr_event) {
   return 0;
 }
 

--- a/ManuvrOS/Platform/Fubarino/Fubarino.cpp
+++ b/ManuvrOS/Platform/Fubarino/Fubarino.cpp
@@ -185,7 +185,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-void setPinEvent(uint8_t pin, uint8_t condition, ManuvrRunnable* isr_event) {
+void setPinEvent(uint8_t pin, uint8_t condition, ManuvrMsg* isr_event) {
 }
 
 

--- a/ManuvrOS/Platform/Identity.cpp
+++ b/ManuvrOS/Platform/Identity.cpp
@@ -160,7 +160,7 @@ void Identity::staticToString(Identity* ident, StringBuilder* output) {
     output->concat("++ REVOKED\n");
   }
 
-  const char* o_str = "someone else.\n";
+  const char* o_str = "someone else.";
   if (ident->_ident_flag(MANUVR_IDENT_FLAG_OUR_OWN)) {
     o_str = "us.";
   }

--- a/ManuvrOS/Platform/Identity.h
+++ b/ManuvrOS/Platform/Identity.h
@@ -105,9 +105,12 @@ class Identity {
       return _serialize(buf, _ident_len);
     };
 
-    inline int   length() {     return _ident_len;  };
-    inline bool  isDirty() {    return _ident_flag(MANUVR_IDENT_FLAG_DIRTY);  };
-    inline bool  isValid() {    return _ident_flag(MANUVR_IDENT_FLAG_VALID);  };
+    inline int   length() {   return _ident_len;  };
+    inline bool  isDirty() {  return _ident_flag(MANUVR_IDENT_FLAG_DIRTY);   };
+    inline bool  isValid() {  return _ident_flag(MANUVR_IDENT_FLAG_VALID);   };
+    inline bool  isSelf() {   return _ident_flag(MANUVR_IDENT_FLAG_OUR_OWN); };
+
+    inline void  isSelf(bool x) {  _ident_set_flag(x, MANUVR_IDENT_FLAG_OUR_OWN); };
 
     inline char* getHandle() {  return (nullptr == _handle ? (char*) "unnamed":_handle);  };
     Identity* getIdentity(IdentFormat);

--- a/ManuvrOS/Platform/Linux/LinuxStorage.cpp
+++ b/ManuvrOS/Platform/Linux/LinuxStorage.cpp
@@ -242,7 +242,7 @@ int8_t LinuxStorage::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t LinuxStorage::callback_proc(ManuvrRunnable *event) {
+int8_t LinuxStorage::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -272,7 +272,7 @@ void LinuxStorage::printDebug(StringBuilder *output) {
 /*
 * This is the override from EventReceiver.
 */
-int8_t LinuxStorage::notify(ManuvrRunnable *active_event) {
+int8_t LinuxStorage::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Platform/Linux/LinuxStorage.cpp
+++ b/ManuvrOS/Platform/Linux/LinuxStorage.cpp
@@ -336,7 +336,7 @@ void LinuxStorage::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif   // MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/Platform/Linux/LinuxStorage.h
+++ b/ManuvrOS/Platform/Linux/LinuxStorage.h
@@ -50,8 +50,8 @@ class LinuxStorage : public EventReceiver, public Storage {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable*);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif

--- a/ManuvrOS/Platform/Linux/Unsupported.cpp
+++ b/ManuvrOS/Platform/Linux/Unsupported.cpp
@@ -35,7 +35,7 @@ extern "C" {
   }
 
   void unsetPinIRQ(uint8_t pin) {}
-  int8_t setPinEvent(uint8_t, uint8_t, ManuvrRunnable*) {  return 0;  }
+  int8_t setPinEvent(uint8_t, uint8_t, ManuvrMsg*) {  return 0;  }
   int8_t setPinFxn(uint8_t, uint8_t, FxnPointer) {         return 0;  }
   int8_t gpioDefine(uint8_t pin, int mode) {               return 0;  }
   int8_t setPin(uint8_t pin, bool val) {                   return 0;  }

--- a/ManuvrOS/Platform/Particle/Photon.cpp
+++ b/ManuvrOS/Platform/Particle/Photon.cpp
@@ -28,8 +28,6 @@ Particle Photon support...
 /****************************************************************************************************
 * The code under this block is special on this platform, and will not be available elsewhere.       *
 ****************************************************************************************************/
-volatile Kernel* __kernel = nullptr;
-
 
 /****************************************************************************************************
 * Watchdog                                                                                          *
@@ -265,7 +263,6 @@ volatile void reboot() {
 */
 int8_t platformPreInit(Argument* root_opts) {
   ManuvrPlatform::platformPreInit(root_config);
-  __kernel = (volatile Kernel*) &_kernel;
   gpioSetup();
   init_RNG();
   initPlatformRTC();

--- a/ManuvrOS/Platform/Platform.cpp
+++ b/ManuvrOS/Platform/Platform.cpp
@@ -323,7 +323,7 @@ void ManuvrPlatform::_discoverALUParams() {
 */
 int8_t ManuvrPlatform::bootstrap() {
   /* Follow your shadow. */
-  ManuvrRunnable* boot_completed_ev = Kernel::returnEvent(MANUVR_MSG_SYS_BOOT_COMPLETED);
+  ManuvrMsg* boot_completed_ev = Kernel::returnEvent(MANUVR_MSG_SYS_BOOT_COMPLETED);
   boot_completed_ev->priority = EVENT_PRIORITY_HIGHEST;
   Kernel::staticRaiseEvent(boot_completed_ev);
   _set_init_state(MANUVR_INIT_STATE_KERNEL_BOOTING);
@@ -333,7 +333,7 @@ int8_t ManuvrPlatform::bootstrap() {
   #if defined(MANUVR_STORAGE)
     if (0 == _load_config()) {
       // If the config loaded, broadcast it.
-      ManuvrRunnable* conf_ev = Kernel::returnEvent(MANUVR_MSG_SYS_CONF_LOAD);
+      ManuvrMsg* conf_ev = Kernel::returnEvent(MANUVR_MSG_SYS_CONF_LOAD);
       // ???Necessary???  conf_ev->addArg(_config);
       Kernel::staticRaiseEvent(conf_ev);
     }

--- a/ManuvrOS/Platform/Platform.cpp
+++ b/ManuvrOS/Platform/Platform.cpp
@@ -491,6 +491,16 @@ int deleteThread(unsigned long* _thread_id) {
 }
 
 
+int wakeThread(unsigned long* _thread_id) {
+  #if defined(__MANUVR_LINUX)
+  #elif defined(__MANUVR_FREERTOS)
+  vTaskResume(_thread_id);
+  return 0;
+  #endif
+  return -1;
+}
+
+
 /**
 * Wrapper for causing threads to sleep. This is NOT intended to be used as a delay
 *   mechanism, although that use-case will work. It is more for the sake of not

--- a/ManuvrOS/Platform/Platform.h
+++ b/ManuvrOS/Platform/Platform.h
@@ -166,7 +166,7 @@ class Storage;
 //         define 60 pins this way. Can't add to a list of const's, so it can't
 //         be both run-time definable AND const.
 typedef struct __platform_gpio_def {
-  ManuvrRunnable* event;
+  ManuvrMsg* event;
   FxnPointer fxn;
   uint8_t         pin;
   uint8_t         flags;
@@ -379,7 +379,7 @@ volatile bool provide_random_int(uint32_t);  // Provides a new random to the poo
 */
 int8_t gpioDefine(uint8_t pin, int mode);
 void   unsetPinIRQ(uint8_t pin);
-int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrRunnable* isr_event);
+int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrMsg* isr_event);
 int8_t setPinFxn(uint8_t pin, uint8_t condition, FxnPointer fxn);
 int8_t setPin(uint8_t pin, bool high);
 int8_t readPin(uint8_t pin);

--- a/ManuvrOS/Platform/Raspi/Raspi.cpp
+++ b/ManuvrOS/Platform/Raspi/Raspi.cpp
@@ -272,7 +272,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrRunnable* isr_event) {
+int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrMsg* isr_event) {
   return 0;
 }
 

--- a/ManuvrOS/Platform/STM32F4/STM32F4.cpp
+++ b/ManuvrOS/Platform/STM32F4/STM32F4.cpp
@@ -190,7 +190,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-void setPinEvent(uint8_t pin, ManuvrRunnable* isr_event) {
+void setPinEvent(uint8_t pin, ManuvrMsg* isr_event) {
 }
 
 

--- a/ManuvrOS/Platform/STM32F7/STM32F7.cpp
+++ b/ManuvrOS/Platform/STM32F7/STM32F7.cpp
@@ -464,7 +464,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-int8_t setPinEvent(uint8_t _pin, uint8_t condition, ManuvrRunnable* isr_event) {
+int8_t setPinEvent(uint8_t _pin, uint8_t condition, ManuvrMsg* isr_event) {
   uint16_t pin_idx   = (_pin % 16);
 
   if (0 == __ext_line_bindings[pin_idx].condition) {

--- a/ManuvrOS/Platform/STM32F7/STM32F7.h
+++ b/ManuvrOS/Platform/STM32F7/STM32F7.h
@@ -38,10 +38,10 @@ limitations under the License.
 * External interrupt actions are stored this way in an array, with indecies
 *   corresponding to the EXTI source.
 * If both values are non-NULL, they will both be proc'd, with the function call
-*   preceeding Runnable insertion to the Kernel's ISR queue.
+*   preceeding Msg insertion to the Kernel's ISR queue.
 */
 typedef struct __platform_exti_def {
-  ManuvrRunnable* event;
+  ManuvrMsg* event;
   FxnPointer fxn;
   uint8_t         pin;
   uint8_t         condition;

--- a/ManuvrOS/Platform/Teensy3/Teensy3.cpp
+++ b/ManuvrOS/Platform/Teensy3/Teensy3.cpp
@@ -26,6 +26,8 @@ This file is meant to contain a set of common functions that are typically platf
     * Access a true RNG (if it exists)
 */
 
+
+#include <CommonConstants.h>
 #include <Platform/Platform.h>
 
 #if defined(MANUVR_STORAGE)

--- a/ManuvrOS/Platform/Teensy3/Teensy3.cpp
+++ b/ManuvrOS/Platform/Teensy3/Teensy3.cpp
@@ -270,7 +270,7 @@ void unsetPinIRQ(uint8_t pin) {
 }
 
 
-int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrRunnable* isr_event) {
+int8_t setPinEvent(uint8_t pin, uint8_t condition, ManuvrMsg* isr_event) {
   return 0;
 }
 

--- a/ManuvrOS/Platform/Teensy3/TeensyStorage.cpp
+++ b/ManuvrOS/Platform/Teensy3/TeensyStorage.cpp
@@ -187,7 +187,7 @@ int8_t TeensyStorage::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t TeensyStorage::callback_proc(ManuvrRunnable *event) {
+int8_t TeensyStorage::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -216,7 +216,7 @@ void TeensyStorage::printDebug(StringBuilder *output) {
 /*
 * This is the override from EventReceiver.
 */
-int8_t TeensyStorage::notify(ManuvrRunnable *active_event) {
+int8_t TeensyStorage::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Platform/Teensy3/TeensyStorage.cpp
+++ b/ManuvrOS/Platform/Teensy3/TeensyStorage.cpp
@@ -304,7 +304,7 @@ void TeensyStorage::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif   // MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/Platform/Teensy3/TeensyStorage.h
+++ b/ManuvrOS/Platform/Teensy3/TeensyStorage.h
@@ -47,8 +47,8 @@ class TeensyStorage : public EventReceiver, public Storage {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable*);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif

--- a/ManuvrOS/Rationalizer.h
+++ b/ManuvrOS/Rationalizer.h
@@ -31,6 +31,11 @@
   // JSON
   // Base64 (URL-Safe?)
 
+#if defined(WITH_MBEDTLS) && defined(MBEDTLS_BASE64_C)
+  #define __BUILD_HAS_BASE64
+#endif
+
+
 
 /* BufferPipe support... */
 
@@ -59,15 +64,6 @@
     #define __HAS_IDENT_ONEID     // We support OneID's asymmetric identities.
   #endif
 #endif   // __HAS_CRYPT_WRAPPER
-
-
-
-
-
-
-
-
-
 
 
 #endif // __MANUVR_OPTION_RATIONALIZER_H__

--- a/ManuvrOS/Transports/BufferPipes/ManuvrGPS/ManuvrGPS.h
+++ b/ManuvrOS/Transports/BufferPipes/ManuvrGPS/ManuvrGPS.h
@@ -258,7 +258,7 @@ class ManuvrGPS : public BufferPipe {
   private:
     uint32_t       _sentences_parsed;
     StringBuilder  _accumulator;
-    ManuvrRunnable _gps_frame;
+    ManuvrMsg _gps_frame;
 
     bool _attempt_parse();
 

--- a/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
+++ b/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
@@ -390,8 +390,8 @@ int8_t ManuvrSerial::attached() {
   read_abort_event.alterSchedulePeriod(30);
   read_abort_event.autoClear(false);
   read_abort_event.enableSchedule(true);
-  #if !defined (__MANUVR_FREERTOS) && !defined (__MANUVR_LINUX)
-  __kernel->addSchedule(&read_abort_event);
+  #if !defined (__BUILD_HAS_THREADS)
+  platform.kernel()->addSchedule(&read_abort_event);
   #endif
 
   reset();

--- a/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
+++ b/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
@@ -30,8 +30,8 @@ Platforms that require it should be able to extend this driver for specific
 */
 
 
-#include "ManuvrSerial.h"
 #include <CommonConstants.h>
+#include "ManuvrSerial.h"
 
 #include <Kernel.h>
 #include <Platform/Platform.h>
@@ -295,6 +295,16 @@ int8_t ManuvrSerial::read_port() {
           return_value = 1;
         }
     #elif defined (ARDUINO)        // Fall-through case for basic Arduino support.
+        if (Serial.available()) {
+          while (Serial.available()) {
+            *(buf + n++) = Serial.read();
+          }
+          bytes_received += n;
+          *(buf + n) = '\0';  // NULL-terminate, JIC
+          BufferPipe::fromCounterparty(buf, n, MEM_MGMT_RESPONSIBLE_BEARER);
+          Serial.print((char*) buf);
+          return_value = 1;
+        }
 
     #elif defined (__MANUVR_LINUX) // Linux with pthreads...
         n = read(_sock, buf, 255);

--- a/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
+++ b/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.cpp
@@ -432,7 +432,7 @@ void ManuvrSerial::printDebug(StringBuilder *temp) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrSerial::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrSerial::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -450,7 +450,7 @@ int8_t ManuvrSerial::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t ManuvrSerial::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrSerial::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.h
+++ b/ManuvrOS/Transports/ManuvrSerial/ManuvrSerial.h
@@ -67,8 +67,8 @@ class ManuvrSerial : public ManuvrXport {
     /* Overrides from EventReceiver */
     int8_t attached();
     void printDebug(StringBuilder *);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
     int8_t connect();

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrSocket.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrSocket.cpp
@@ -104,7 +104,6 @@ void ManuvrSocket::__class_initializer() {
   read_abort_event.repurpose(MANUVR_MSG_XPORT_QUEUE_RDY, (EventReceiver*) this);
   read_abort_event.isManaged(true);
   read_abort_event.specific_target = (EventReceiver*) this;
-  read_abort_event.addArg(xport_id);  // Add our assigned transport ID to our pre-baked argument.
 }
 
 

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.cpp
@@ -94,7 +94,7 @@ This is basically only for linux for now.
           ManuvrTCP* nu_connection = new ManuvrTCP(listening_inst, cli_sock, &cli_addr);
           nu_connection->setPipeStrategy(listening_inst->getPipeStrategy());
 
-          ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_SYS_ADVERTISE_SRVC);
+          ManuvrMsg* event = Kernel::returnEvent(MANUVR_MSG_SYS_ADVERTISE_SRVC);
           event->addArg((EventReceiver*) nu_connection);
           Kernel::staticRaiseEvent(event);
 
@@ -431,7 +431,7 @@ void ManuvrTCP::printDebug(StringBuilder *temp) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrTCP::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrTCP::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -450,7 +450,7 @@ int8_t ManuvrTCP::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ManuvrTCP::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrTCP::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.cpp
@@ -397,7 +397,7 @@ int8_t ManuvrTCP::attached() {
   read_abort_event.alterSchedulePeriod(300);
   read_abort_event.autoClear(false);
   read_abort_event.enableSchedule(false);
-  __kernel->addSchedule(&read_abort_event);
+  platform.kernel()->addSchedule(&read_abort_event);
 
   reset();
   return 1;

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.h
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrTCP.h
@@ -63,8 +63,8 @@ class ManuvrTCP : public ManuvrSocket {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder *);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
     int8_t connect();

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
@@ -491,7 +491,7 @@ int8_t ManuvrUDP::attached() {
   read_abort_event.autoClear(false);
   read_abort_event.enableSchedule(false);
   read_abort_event.enableSchedule(false);
-  //__kernel->addSchedule(&read_abort_event);
+  //platform.kernel()->addSchedule(&read_abort_event);
 
   listen();
   return 1;

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
@@ -326,7 +326,7 @@ int8_t ManuvrUDP::read_port() {
         //   a system-wide message if mem-mgmt responsibility for the buffer was
         //   accepted by the bearer.
         _open_replies[cli_addr.sin_port] = related_pipe;
-        ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_XPORT_RECEIVE);
+        ManuvrMsg* event = Kernel::returnEvent(MANUVR_MSG_XPORT_RECEIVE);
         // Because we allocated the pipe, we must clean it up if it is not taken.
         event->setOriginator((EventReceiver*) this);
         //event->addArg(related_pipe);   // Add the newly-minted pipe.
@@ -533,7 +533,7 @@ void ManuvrUDP::printDebug(StringBuilder* output) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrUDP::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrUDP::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -571,7 +571,7 @@ int8_t ManuvrUDP::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ManuvrUDP::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrUDP::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.cpp
@@ -602,7 +602,7 @@ void ManuvrUDP::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.h
+++ b/ManuvrOS/Transports/ManuvrSocket/ManuvrUDP.h
@@ -149,8 +149,8 @@ class ManuvrUDP : public ManuvrSocket {
     };
 
     /* Overrides from EventReceiver */
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     void printDebug(StringBuilder*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);

--- a/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
+++ b/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
@@ -67,7 +67,7 @@ TODO: It does not do this. Need to finish addressing issues with the build
         else {
           ManuvrTelehash* nu_connection = new ManuvrTelehash(listening_inst, cli_sock, &cli_addr);
 
-          ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_SYS_ADVERTISE_SRVC);
+          ManuvrMsg* event = Kernel::returnEvent(MANUVR_MSG_SYS_ADVERTISE_SRVC);
           event->addArg((EventReceiver*) nu_connection);
           Kernel::staticRaiseEvent(event);
 
@@ -307,7 +307,7 @@ int8_t ManuvrTelehash::read_port() {
   if (connected()) {
     unsigned char *buf = (unsigned char *) alloca(256);
     int n;
-    ManuvrRunnable *event    = NULL;
+    ManuvrMsg *event    = NULL;
     StringBuilder  *nu_data  = NULL;
 
     while (connected()) {
@@ -466,7 +466,7 @@ void ManuvrTelehash::printDebug(StringBuilder *temp) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrTelehash::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrTelehash::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -485,7 +485,7 @@ int8_t ManuvrTelehash::callback_proc(ManuvrRunnable *event) {
 
 
 
-int8_t ManuvrTelehash::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrTelehash::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
+++ b/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
@@ -175,7 +175,6 @@ void ManuvrTelehash::__class_initializer() {
   read_abort_event.isManaged(true);
   read_abort_event.specific_target = (EventReceiver*) this;
   read_abort_event.priority        = 5;
-  read_abort_event.addArg(xport_id);  // Add our assigned transport ID to our pre-baked argument.
 
   /*
   TODO: Wrap this up into the efficiency blog...

--- a/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
+++ b/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.cpp
@@ -430,7 +430,7 @@ int8_t ManuvrTelehash::attached() {   // ?? TODO ??
   read_abort_event.autoClear(false);
   read_abort_event.enableSchedule(false);
   read_abort_event.enableSchedule(false);
-  __kernel->addSchedule(&read_abort_event);
+  platform.kernel()->addSchedule(&read_abort_event);
 
   reset();
   return 1;

--- a/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.h
+++ b/ManuvrOS/Transports/ManuvrTelehash/ManuvrTelehash.h
@@ -60,8 +60,8 @@ class ManuvrTelehash : public ManuvrXport {
     /* Overrides from EventReceiver */
     int8_t attached();
     void printDebug(StringBuilder *);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
     int8_t connect();

--- a/ManuvrOS/Transports/ManuvrXport.cpp
+++ b/ManuvrOS/Transports/ManuvrXport.cpp
@@ -237,7 +237,7 @@ void ManuvrXport::autoConnect(bool en, uint32_t _ac_period) {
       _xport_flags = (en) ? (_xport_flags | MANUVR_XPORT_FLAG_AUTO_CONNECT) : (_xport_flags & ~(MANUVR_XPORT_FLAG_AUTO_CONNECT));
       if (nullptr == _autoconnect_schedule) {
         // If we don't already have a ref to a schedule for this purpose.
-        _autoconnect_schedule = new ManuvrRunnable(MANUVR_MSG_XPORT_CONNECT, (EventReceiver*) this);
+        _autoconnect_schedule = new ManuvrMsg(MANUVR_MSG_XPORT_CONNECT, (EventReceiver*) this);
         _autoconnect_schedule->isManaged(true);
         _autoconnect_schedule->specific_target = (EventReceiver*) this;
         _autoconnect_schedule->alterScheduleRecurrence(-1);
@@ -341,7 +341,7 @@ void ManuvrXport::printDebug(StringBuilder *temp) {
 }
 
 
-int8_t ManuvrXport::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrXport::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/ManuvrXport.cpp
+++ b/ManuvrOS/Transports/ManuvrXport.cpp
@@ -148,7 +148,7 @@ ManuvrXport::~ManuvrXport() {
   // Cleanup any schedules...
   if (NULL != _autoconnect_schedule) {
     _autoconnect_schedule->enableSchedule(false);
-    __kernel->removeSchedule(_autoconnect_schedule);
+    platform.kernel()->removeSchedule(_autoconnect_schedule);
     _autoconnect_schedule = NULL;
     delete _autoconnect_schedule;
   }
@@ -233,7 +233,7 @@ void ManuvrXport::alwaysConnected(bool en) {
   if (NULL != _autoconnect_schedule) {
     // If we have a reconnection schedule (we should not), free it.
     _autoconnect_schedule->enableSchedule(false);
-    __kernel->removeSchedule(_autoconnect_schedule);
+    platform.kernel()->removeSchedule(_autoconnect_schedule);
     _autoconnect_schedule = NULL;
     delete _autoconnect_schedule;
   }
@@ -260,14 +260,14 @@ void ManuvrXport::autoConnect(bool en, uint32_t _ac_period) {
         _autoconnect_schedule->alterSchedulePeriod(_ac_period);
         _autoconnect_schedule->autoClear(false);
         _autoconnect_schedule->enableSchedule(!connected());
-        __kernel->addSchedule(_autoconnect_schedule);
+        platform.kernel()->addSchedule(_autoconnect_schedule);
       }
     }
   }
   else {
     if (NULL != _autoconnect_schedule) {
       _autoconnect_schedule->enableSchedule(false);
-      __kernel->removeSchedule(_autoconnect_schedule);
+      platform.kernel()->removeSchedule(_autoconnect_schedule);
       delete _autoconnect_schedule;
       _autoconnect_schedule = NULL;
     }

--- a/ManuvrOS/Transports/ManuvrXport.h
+++ b/ManuvrOS/Transports/ManuvrXport.h
@@ -151,10 +151,6 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
 
   protected:
     ManuvrRunnable* _autoconnect_schedule;
-    #if defined(__BUILD_HAS_THREADS)
-      // If we have a concept of threads...
-      unsigned long _thread_id;
-    #endif
 
     // Can also be used to poll the other side. Implementation is completely at the discretion
     //   any extending class. But generally, this feature is necessary.

--- a/ManuvrOS/Transports/ManuvrXport.h
+++ b/ManuvrOS/Transports/ManuvrXport.h
@@ -79,9 +79,6 @@ This driver is designed to give Manuvr platform-abstracted transports.
 
 #define XPORT_DEFAULT_AUTOCONNECT_PERIOD 15000  // In ms. Unless otherwise specified...
 
-class XenoSession;
-
-
 class ManuvrXport : public EventReceiver, public BufferPipe {
   public:
     virtual ~ManuvrXport();
@@ -143,22 +140,16 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
       virtual void   procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT
 
-    // We can have up-to 65535 transport instances concurrently. This well-exceeds
-    //   the configured limits of most linux installations, so it should be enough.
-    static uint16_t TRANSPORT_ID_POOL;
-
-
 
   protected:
+    uint32_t _xport_mtu;      // The largest packet size we handle.
+    uint32_t bytes_sent      = 0;
+    uint32_t bytes_received  = 0;
     ManuvrRunnable* _autoconnect_schedule = nullptr;
 
     // Can also be used to poll the other side. Implementation is completely at the discretion
     //   any extending class. But generally, this feature is necessary.
     ManuvrRunnable read_abort_event;  // Used to timeout a read operation.
-
-    uint32_t _xport_mtu;      // The largest packet size we handle.
-    uint32_t bytes_sent      = 0;
-    uint32_t bytes_received  = 0;
 
     ManuvrXport();
 

--- a/ManuvrOS/Transports/ManuvrXport.h
+++ b/ManuvrOS/Transports/ManuvrXport.h
@@ -150,16 +150,15 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
 
 
   protected:
-    ManuvrRunnable* _autoconnect_schedule;
+    ManuvrRunnable* _autoconnect_schedule = nullptr;
 
     // Can also be used to poll the other side. Implementation is completely at the discretion
     //   any extending class. But generally, this feature is necessary.
     ManuvrRunnable read_abort_event;  // Used to timeout a read operation.
 
-    uint16_t xport_id;
     uint32_t _xport_mtu;      // The largest packet size we handle.
-    uint32_t bytes_sent;
-    uint32_t bytes_received;
+    uint32_t bytes_sent      = 0;
+    uint32_t bytes_received  = 0;
 
     ManuvrXport();
 
@@ -176,7 +175,7 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
 
 
   private:
-    uint32_t _xport_flags = 0;;
+    uint32_t _xport_flags = 0;
 
     /* Connection/Listen states */
     inline void mark_connected(bool en) {

--- a/ManuvrOS/Transports/ManuvrXport.h
+++ b/ManuvrOS/Transports/ManuvrXport.h
@@ -135,7 +135,7 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
     // TODO: I'm not sure I've evaluated the full impact of this sort of
     //    choice.  Calltimes? vtable size? alignment? Fragility? Dig.
     virtual void   printDebug(StringBuilder *);
-    virtual int8_t notify(ManuvrRunnable*);
+    virtual int8_t notify(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       virtual void   procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT
@@ -145,11 +145,11 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
     uint32_t _xport_mtu;      // The largest packet size we handle.
     uint32_t bytes_sent      = 0;
     uint32_t bytes_received  = 0;
-    ManuvrRunnable* _autoconnect_schedule = nullptr;
+    ManuvrMsg* _autoconnect_schedule = nullptr;
 
     // Can also be used to poll the other side. Implementation is completely at the discretion
     //   any extending class. But generally, this feature is necessary.
-    ManuvrRunnable read_abort_event;  // Used to timeout a read operation.
+    ManuvrMsg read_abort_event;  // Used to timeout a read operation.
 
     ManuvrXport();
 

--- a/ManuvrOS/Transports/ManuvrXport.h
+++ b/ManuvrOS/Transports/ManuvrXport.h
@@ -176,7 +176,7 @@ class ManuvrXport : public EventReceiver, public BufferPipe {
 
 
   private:
-    uint32_t _xport_flags;
+    uint32_t _xport_flags = 0;;
 
     /* Connection/Listen states */
     inline void mark_connected(bool en) {

--- a/ManuvrOS/Transports/StandardIO/StandardIO.cpp
+++ b/ManuvrOS/Transports/StandardIO/StandardIO.cpp
@@ -87,7 +87,6 @@ void StandardIO::__class_initializer() {
   read_abort_event.isManaged(true);
   read_abort_event.specific_target = (EventReceiver*) this;
   read_abort_event.priority        = 5;
-  read_abort_event.addArg(xport_id);  // Add our assigned transport ID to our pre-baked argument.
   _bp_set_flag(BPIPE_FLAG_PIPE_PACKETIZED, true);
 }
 

--- a/ManuvrOS/Transports/StandardIO/StandardIO.cpp
+++ b/ManuvrOS/Transports/StandardIO/StandardIO.cpp
@@ -253,7 +253,7 @@ void StandardIO::printDebug(StringBuilder *temp) {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t StandardIO::callback_proc(ManuvrRunnable *event) {
+int8_t StandardIO::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -271,7 +271,7 @@ int8_t StandardIO::callback_proc(ManuvrRunnable *event) {
 }
 
 
-int8_t StandardIO::notify(ManuvrRunnable *active_event) {
+int8_t StandardIO::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/Transports/StandardIO/StandardIO.h
+++ b/ManuvrOS/Transports/StandardIO/StandardIO.h
@@ -52,8 +52,8 @@ class StandardIO : public ManuvrXport {
     /* Overrides from EventReceiver */
     int8_t attached();
     void printDebug(StringBuilder *);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable*);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
     /* Overrides from ManuvrXport */
     int8_t connect();

--- a/ManuvrOS/Utilities.cpp
+++ b/ManuvrOS/Utilities.cpp
@@ -11,6 +11,7 @@
 */
 
 #include <inttypes.h>
+#include <CommonConstants.h>
 #include <DataStructures/StringBuilder.h>
 
 #define XLIM 17
@@ -92,9 +93,11 @@ int randomArt(uint8_t* dgst_raw, unsigned int dgst_raw_len, const char* title, S
   return 0;
 }
 
-#if defined(WITH_MBEDTLS)
+#if defined(__BUILD_HAS_BASE64)
 #include "mbedtls/base64.h"
 int wrapped_base64_decode(uint8_t* dst, size_t dlen, size_t* olen, const uint8_t* src, size_t slen) {
-  return mbedtls_base64_decode(dst, dlen, olen, src, slen);
+  #if defined(WITH_MBEDTLS)
+    return mbedtls_base64_decode(dst, dlen, olen, src, slen);
+  #endif
 }
 #endif

--- a/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
+++ b/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
@@ -287,7 +287,7 @@ void CoAPSession::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
+++ b/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
@@ -75,7 +75,7 @@ CoAPSession::CoAPSession(BufferPipe* _near_side) : XenoSession(_near_side) {
 */
 CoAPSession::~CoAPSession() {
   _ping_timer.enableSchedule(false);
-  __kernel->removeSchedule(&_ping_timer);
+  platform.kernel()->removeSchedule(&_ping_timer);
 
 	if (NULL != working) {
 		delete working;
@@ -182,7 +182,7 @@ int8_t CoAPSession::sendEvent(ManuvrRunnable *active_event) {
 int8_t CoAPSession::attached() {
   EventReceiver::attached();
 
-  __kernel->addSchedule(&_ping_timer);
+  platform.kernel()->addSchedule(&_ping_timer);
 
   //if (owner->connected()) {
     // Are we connected right now?

--- a/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
+++ b/ManuvrOS/XenoSession/CoAP/CoAPSession.cpp
@@ -155,7 +155,7 @@ int8_t CoAPSession::connection_callback(bool _con) {
 * Passing an Event into this fxn will cause the Event to be serialized and sent to our counter-party.
 * This is the point at which choices are made about what happens to the event's life-cycle.
 */
-int8_t CoAPSession::sendEvent(ManuvrRunnable *active_event) {
+int8_t CoAPSession::sendEvent(ManuvrMsg* active_event) {
   return 0;
 }
 
@@ -206,7 +206,7 @@ int8_t CoAPSession::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t CoAPSession::callback_proc(ManuvrRunnable *event) {
+int8_t CoAPSession::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -228,7 +228,7 @@ int8_t CoAPSession::callback_proc(ManuvrRunnable *event) {
 *   a list of events that it has been instructed to relay to the counterparty. If the event
 *   meets the relay criteria, we serialize it and send it to the transport that we are bound to.
 */
-int8_t CoAPSession::notify(ManuvrRunnable *active_event) {
+int8_t CoAPSession::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/XenoSession/CoAP/CoAPSession.h
+++ b/ManuvrOS/XenoSession/CoAP/CoAPSession.h
@@ -295,10 +295,10 @@ class CoAPSession : public XenoSession {
     CoAPSession(BufferPipe*);
     ~CoAPSession();
 
-    int8_t sendEvent(ManuvrRunnable*);
+    int8_t sendEvent(ManuvrMsg*);
 
     /* Management of subscriptions... */
-    int8_t subscribe(const char*, ManuvrRunnable*);  // Start getting broadcasts about a given message type.
+    int8_t subscribe(const char*, ManuvrMsg*);  // Start getting broadcasts about a given message type.
     int8_t unsubscribe(const char*);                 // Stop getting broadcasts about a given message type.
     int8_t resubscribeAll();
     int8_t unsubscribeAll();
@@ -311,8 +311,8 @@ class CoAPSession : public XenoSession {
     /* Overrides from EventReceiver */
     void procDirectDebugInstruction(StringBuilder*);
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
   protected:
@@ -323,7 +323,7 @@ class CoAPSession : public XenoSession {
     CoAPMessage* working;
 
     PriorityQueue<CoAPMessage*> _pending_coap_messages;      // Valid CoAP messages that have arrived.
-    ManuvrRunnable _ping_timer;    // Periodic KA ping.
+    ManuvrMsg _ping_timer;    // Periodic KA ping.
 
     unsigned int _next_packetid;
 

--- a/ManuvrOS/XenoSession/Console/ManuvrConsole.cpp
+++ b/ManuvrOS/XenoSession/Console/ManuvrConsole.cpp
@@ -120,7 +120,7 @@ int8_t ManuvrConsole::fromCounterparty(StringBuilder* buf, int8_t mm) {
       // Begin the cases...
       #if defined(_GNU_SOURCE)
         if (strcasestr(temp_ptr, "QUIT")) {
-          ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_SYS_REBOOT);
+          ManuvrMsg* event = Kernel::returnEvent(MANUVR_MSG_SYS_REBOOT);
           event->setOriginator((EventReceiver*) platform.kernel());
           Kernel::staticRaiseEvent(event);
         }
@@ -131,7 +131,7 @@ int8_t ManuvrConsole::fromCounterparty(StringBuilder* buf, int8_t mm) {
         // If the ISR saw a CR or LF on the wire, we tell the parser it is ok to
         // run in idle time.
         StringBuilder* dispatched = new StringBuilder((uint8_t*) temp_ptr, temp_len);
-        ManuvrRunnable* event  = Kernel::returnEvent(MANUVR_MSG_USER_DEBUG_INPUT);
+        ManuvrMsg* event  = Kernel::returnEvent(MANUVR_MSG_USER_DEBUG_INPUT);
         event->specific_target = (EventReceiver*) platform.kernel();
         event->setOriginator((EventReceiver*) this);
         event->addArg(dispatched)->reapValue(true);
@@ -185,7 +185,7 @@ int8_t ManuvrConsole::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrConsole::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrConsole::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -233,7 +233,7 @@ void ManuvrConsole::printDebug(StringBuilder *output) {
 *   a list of events that it has been instructed to relay to the counterparty. If the event
 *   meets the relay criteria, we serialize it and send it to the transport that we are bound to.
 */
-int8_t ManuvrConsole::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrConsole::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/XenoSession/Console/ManuvrConsole.cpp
+++ b/ManuvrOS/XenoSession/Console/ManuvrConsole.cpp
@@ -121,7 +121,7 @@ int8_t ManuvrConsole::fromCounterparty(StringBuilder* buf, int8_t mm) {
       #if defined(_GNU_SOURCE)
         if (strcasestr(temp_ptr, "QUIT")) {
           ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_SYS_REBOOT);
-          event->setOriginator((EventReceiver*) __kernel);
+          event->setOriginator((EventReceiver*) platform.kernel());
           Kernel::staticRaiseEvent(event);
         }
         else if (strcasestr(temp_ptr, "HELP"))  printHelp();      // Show help.
@@ -132,7 +132,7 @@ int8_t ManuvrConsole::fromCounterparty(StringBuilder* buf, int8_t mm) {
         // run in idle time.
         StringBuilder* dispatched = new StringBuilder((uint8_t*) temp_ptr, temp_len);
         ManuvrRunnable* event  = Kernel::returnEvent(MANUVR_MSG_USER_DEBUG_INPUT);
-        event->specific_target = (EventReceiver*) __kernel;
+        event->specific_target = (EventReceiver*) platform.kernel();
         event->setOriginator((EventReceiver*) this);
         event->addArg(dispatched)->reapValue(true);
         raiseEvent(event);

--- a/ManuvrOS/XenoSession/Console/ManuvrConsole.h
+++ b/ManuvrOS/XenoSession/Console/ManuvrConsole.h
@@ -49,8 +49,8 @@ class ManuvrConsole : public XenoSession {
     void procDirectDebugInstruction(StringBuilder*);
     void printDebug(StringBuilder*);
     int8_t attached();
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
   private:

--- a/ManuvrOS/XenoSession/MQTT/MQTTSession.cpp
+++ b/ManuvrOS/XenoSession/MQTT/MQTTSession.cpp
@@ -649,7 +649,7 @@ void MQTTSession::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/XenoSession/MQTT/MQTTSession.cpp
+++ b/ManuvrOS/XenoSession/MQTT/MQTTSession.cpp
@@ -83,7 +83,7 @@ MQTTSession::MQTTSession(ManuvrXport* _xport) : XenoSession(_xport) {
 */
 MQTTSession::~MQTTSession() {
   _ping_timer.enableSchedule(false);
-  __kernel->removeSchedule(&_ping_timer);
+  platform.kernel()->removeSchedule(&_ping_timer);
 
 	if (NULL != working) {
 		delete working;
@@ -498,7 +498,7 @@ int MQTTSession::process_inbound() {
 */
 int8_t MQTTSession::attached() {
   EventReceiver::attached();
-  __kernel->addSchedule(&_ping_timer);
+  platform.kernel()->addSchedule(&_ping_timer);
 
   //if (owner->connected()) {
   //  // Are we connected right now?

--- a/ManuvrOS/XenoSession/MQTT/MQTTSession.h
+++ b/ManuvrOS/XenoSession/MQTT/MQTTSession.h
@@ -89,10 +89,10 @@ class MQTTSession : public XenoSession {
     MQTTSession(ManuvrXport*);
     virtual ~MQTTSession();
 
-    int8_t sendEvent(ManuvrRunnable*);
+    int8_t sendEvent(ManuvrMsg*);
 
     /* Management of subscriptions... */
-    int8_t subscribe(const char*, ManuvrRunnable*);  // Start getting broadcasts about a given message type.
+    int8_t subscribe(const char*, ManuvrMsg*);  // Start getting broadcasts about a given message type.
     int8_t unsubscribe(const char*);                 // Stop getting broadcasts about a given message type.
     int8_t resubscribeAll();
     int8_t unsubscribeAll();
@@ -105,8 +105,8 @@ class MQTTSession : public XenoSession {
     /* Overrides from EventReceiver */
     void procDirectDebugInstruction(StringBuilder*);
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
 
 
   protected:
@@ -116,9 +116,9 @@ class MQTTSession : public XenoSession {
   private:
     MQTTMessage* working;
 
-    std::map<const char*, ManuvrRunnable*> _subscriptions;   // Topics we are subscribed to, and the events they trigger.
+    std::map<const char*, ManuvrMsg*> _subscriptions;   // Topics we are subscribed to, and the events they trigger.
     PriorityQueue<MQTTMessage*> _pending_mqtt_messages;      // Valid MQTT messages that have arrived.
-    ManuvrRunnable _ping_timer;    // Periodic KA ping.
+    ManuvrMsg _ping_timer;    // Periodic KA ping.
 
     unsigned int _next_packetid;
     unsigned int command_timeout_ms;
@@ -140,7 +140,7 @@ class MQTTSession : public XenoSession {
     bool sendKeepAlive();
     bool sendConnectPacket();
     bool sendDisconnectPacket();
-    bool sendPublish(ManuvrRunnable*);
+    bool sendPublish(ManuvrMsg*);
 
     int proc_publish(MQTTMessage*);
     int process_inbound();

--- a/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
+++ b/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
@@ -606,7 +606,7 @@ void ManuvrSession::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  //MANUVR_CONSOLE_SUPPORT
 

--- a/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
+++ b/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
@@ -67,7 +67,7 @@ ManuvrSession::ManuvrSession(ManuvrXport* _xport) : XenoSession(_xport) {
 */
 ManuvrSession::~ManuvrSession() {
   sync_event.enableSchedule(false);
-  __kernel->removeSchedule(&sync_event);
+  platform.kernel()->removeSchedule(&sync_event);
 }
 
 
@@ -483,7 +483,7 @@ int8_t ManuvrSession::attached() {
   sync_event.autoClear(false);
   sync_event.enableSchedule(false);
 
-  __kernel->addSchedule(&sync_event);
+  platform.kernel()->addSchedule(&sync_event);
 
   if (isConnected()) {
     // If we've been instanced because of a connetion, start the sync process...

--- a/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
+++ b/ManuvrOS/XenoSession/Manuvr/ManuvrSession.cpp
@@ -406,7 +406,7 @@ int8_t ManuvrSession::bin_stream_rx(unsigned char *buf, int len) {
 *               ---J. Ian Lindsay   Tue Aug 04 23:12:55 MST 2015
 */
 int8_t ManuvrSession::sendKeepAlive() {
-  ManuvrRunnable* ka_event = Kernel::returnEvent(MANUVR_MSG_SYNC_KEEPALIVE);
+  ManuvrMsg* ka_event = Kernel::returnEvent(MANUVR_MSG_SYNC_KEEPALIVE);
   sendEvent(ka_event);
   return 0;
 }
@@ -509,7 +509,7 @@ int8_t ManuvrSession::attached() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t ManuvrSession::callback_proc(ManuvrRunnable *event) {
+int8_t ManuvrSession::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -533,7 +533,7 @@ int8_t ManuvrSession::callback_proc(ManuvrRunnable *event) {
 *   a list of events that it has been instructed to relay to the counterparty. If the event
 *   meets the relay criteria, we serialize it and send it to the transport that we are bound to.
 */
-int8_t ManuvrSession::notify(ManuvrRunnable *active_event) {
+int8_t ManuvrSession::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {

--- a/ManuvrOS/XenoSession/Manuvr/ManuvrSession.h
+++ b/ManuvrOS/XenoSession/Manuvr/ManuvrSession.h
@@ -76,14 +76,14 @@ limitations under the License.
 
 
 /**
-* This class is a special extension of ManuvrRunnable that is intended for communication with
-*   outside devices. This is the abstraction between our internal Runnables and the messaging
+* This class is a special extension of ManuvrMsg that is intended for communication with
+*   outside devices. This is the abstraction between our internal Msgs and the messaging
 *   system of our counterparty.
 */
 class XenoManuvrMessage : public XenoMessage {
   public:
     XenoManuvrMessage();                  // Typical use: building an inbound XemoMessage.
-    XenoManuvrMessage(ManuvrRunnable*);   // Create a new XenoMessage with the given event as source data.
+    XenoManuvrMessage(ManuvrMsg*);   // Create a new XenoMessage with the given event as source data.
 
     ~XenoManuvrMessage() {};
 
@@ -99,8 +99,8 @@ class XenoManuvrMessage : public XenoMessage {
     int serialize(StringBuilder*);       // Returns the number of bytes resulting.
     int accumulate(unsigned char*, int); // Returns the number of bytes consumed.
 
-    void provideEvent(ManuvrRunnable*, uint16_t);  // Call to make this XenoMessage outbound.
-    inline void provideEvent(ManuvrRunnable* runnable) {    // Override to support laziness.
+    void provideEvent(ManuvrMsg*, uint16_t);  // Call to make this XenoMessage outbound.
+    inline void provideEvent(ManuvrMsg* runnable) {    // Override to support laziness.
       provideEvent(runnable, (uint16_t) randomInt());
     };
 
@@ -162,8 +162,8 @@ class ManuvrSession : public XenoSession {
 
     /* Overrides from EventReceiver */
     void printDebug(StringBuilder*);
-    int8_t notify(ManuvrRunnable*);
-    int8_t callback_proc(ManuvrRunnable *);
+    int8_t notify(ManuvrMsg*);
+    int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       void procDirectDebugInstruction(StringBuilder*);
     #endif  //MANUVR_CONSOLE_SUPPORT
@@ -176,7 +176,7 @@ class ManuvrSession : public XenoSession {
 
 
   private:
-    ManuvrRunnable sync_event;
+    ManuvrMsg sync_event;
 
     /*
     * A buffer for holding inbound stream until enough has arrived to parse. This eliminates

--- a/ManuvrOS/XenoSession/Manuvr/XenoManuvrMessage.cpp
+++ b/ManuvrOS/XenoSession/Manuvr/XenoManuvrMessage.cpp
@@ -18,7 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-XenoManuvrMessage is the class that is the interface between ManuvrRunnables and
+XenoManuvrMessage is the class that is the interface between ManuvrMsgs and
   XenoSessions.
      ---J. Ian Lindsay
 */
@@ -173,7 +173,7 @@ XenoManuvrMessage::XenoManuvrMessage() : XenoMessage() {
 }
 
 
-XenoManuvrMessage::XenoManuvrMessage(ManuvrRunnable* existing_event) : XenoMessage(existing_event) {
+XenoManuvrMessage::XenoManuvrMessage(ManuvrMsg* existing_event) : XenoMessage(existing_event) {
   wipe();
   // Should maybe set a flag in the event to indicate that we are now responsible
   //   for memory upkeep? Don't want it to get jerked out from under us and cause a crash.
@@ -207,10 +207,10 @@ void XenoManuvrMessage::wipe() {
 *   calling the constructor with an Event argument.
 * TODO: For safety's sake, the Event is not retained. This has caused us some grief. Re-evaluate...
 *
-* @param   ManuvrRunnable* The Event that is to be communicated.
+* @param   ManuvrMsg* The Event that is to be communicated.
 * @param   uint16_t          An explicitly-provided unique_id so that a dialog can be perpetuated.
 */
-void XenoManuvrMessage::provideEvent(ManuvrRunnable *existing_event, uint16_t manual_id) {
+void XenoManuvrMessage::provideEvent(ManuvrMsg* existing_event, uint16_t manual_id) {
   XenoMessage::provideEvent(existing_event);
   unique_id = manual_id;
   message_code = event->eventCode();                //
@@ -224,7 +224,7 @@ void XenoManuvrMessage::provideEvent(ManuvrRunnable *existing_event, uint16_t ma
 * @return  nonzero if there was a problem.
 */
 int8_t XenoManuvrMessage::ack() {
-  ManuvrRunnable temp_event(MANUVR_MSG_REPLY);
+  ManuvrMsg temp_event(MANUVR_MSG_REPLY);
   provideEvent(&temp_event, unique_id);
   awaitingSend(true);
   return 0;
@@ -237,7 +237,7 @@ int8_t XenoManuvrMessage::ack() {
 * @return  nonzero if there was a problem.
 */
 int8_t XenoManuvrMessage::retry() {
-  ManuvrRunnable temp_event(MANUVR_MSG_REPLY_RETRY);
+  ManuvrMsg temp_event(MANUVR_MSG_REPLY_RETRY);
   provideEvent(&temp_event, unique_id);
   awaitingSend(true);
   retries++;
@@ -252,7 +252,7 @@ int8_t XenoManuvrMessage::retry() {
 * @return  nonzero if there was a problem.
 */
 int8_t XenoManuvrMessage::fail() {
-  ManuvrRunnable temp_event(MANUVR_MSG_REPLY_FAIL);
+  ManuvrMsg temp_event(MANUVR_MSG_REPLY_FAIL);
   provideEvent(&temp_event, unique_id);
   awaitingSend(true);
   return 0;

--- a/ManuvrOS/XenoSession/XenoMessage.cpp
+++ b/ManuvrOS/XenoSession/XenoMessage.cpp
@@ -23,10 +23,19 @@ XenoMessage is the class that unifies our counterparty's message format
 */
 
 #include "XenoMessage.h"
-#include <Kernel.h>
 #include <Platform/Platform.h>
 
 
+/*******************************************************************************
+*      _______.___________.    ___   .___________. __    ______     _______.
+*     /       |           |   /   \  |           ||  |  /      |   /       |
+*    |   (----`---|  |----`  /  ^  \ `---|  |----`|  | |  ,----'  |   (----`
+*     \   \       |  |      /  /_\  \    |  |     |  | |  |        \   \
+* .----)   |      |  |     /  _____  \   |  |     |  | |  `----.----)   |
+* |_______/       |__|    /__/     \__\  |__|     |__|  \______|_______/
+*
+* Static members and initializers should be located here.
+*******************************************************************************/
 
 /**
 * @param   uint8_t The integer code that represents message state.
@@ -47,7 +56,6 @@ const char* XenoMessage::getMessageStateString(uint8_t _s_code) {
     default:                                        return "<UNKNOWN>";
   }
 }
-
 
 
 

--- a/ManuvrOS/XenoSession/XenoMessage.cpp
+++ b/ManuvrOS/XenoSession/XenoMessage.cpp
@@ -73,7 +73,7 @@ XenoMessage::XenoMessage() {
 }
 
 
-XenoMessage::XenoMessage(ManuvrRunnable* existing_event) {
+XenoMessage::XenoMessage(ManuvrMsg* existing_event) {
   wipe();
   // Should maybe set a flag in the event to indicate that we are now responsible
   //   for memory upkeep? Don't want it to get jerked out from under us and cause a crash.
@@ -101,10 +101,10 @@ void XenoMessage::wipe() {
 *   calling the constructor with an Event argument.
 * TODO: For safety's sake, the Event is not retained. This has caused us some grief. Re-evaluate...
 *
-* @param   ManuvrRunnable* The Event that is to be communicated.
+* @param   ManuvrMsg* The Event that is to be communicated.
 * @param   uint16_t          An explicitly-provided unique_id so that a dialog can be perpetuated.
 */
-void XenoMessage::provideEvent(ManuvrRunnable *existing_event) {
+void XenoMessage::provideEvent(ManuvrMsg* existing_event) {
   event = existing_event;  // TODO: Has memory implications...
   proc_state = XENO_MSG_PROC_STATE_AWAITING_SEND;  // Implies we are sending.
 }
@@ -122,6 +122,6 @@ void XenoMessage::printDebug(StringBuilder *output) {
   output->concatf("\t bytes_total     %d\n", bytes_total);
   output->concatf("\t bytes_received  %d\n", bytes_received);
   if (NULL != event) {
-    output->concatf("\t Runnable type   %s\n", event->getMsgTypeString());
+    output->concatf("\t Msg type   %s\n", event->getMsgTypeString());
   }
 }

--- a/ManuvrOS/XenoSession/XenoMessage.h
+++ b/ManuvrOS/XenoSession/XenoMessage.h
@@ -90,20 +90,20 @@ enum TypeFormats {
 
 
 /**
-* This class is a special extension of ManuvrRunnable that is intended for communication with
-*   outside devices. This is the abstraction between our internal Runnables and the messaging
+* This class is a special extension of ManuvrMsg that is intended for communication with
+*   outside devices. This is the abstraction between our internal Msgs and the messaging
 *   system of our counterparty.
 */
 class XenoMessage {
   public:
     XenoMessage();                  // Typical use: building an inbound XemoMessage.
-    XenoMessage(ManuvrRunnable*);   // Create a new XenoMessage with the given event as source data.
+    XenoMessage(ManuvrMsg*);   // Create a new XenoMessage with the given event as source data.
 
     virtual ~XenoMessage() {};
 
     virtual void wipe();            // Call this to put this object into a fresh state (avoid a free/malloc).
     virtual void printDebug(StringBuilder*);
-    virtual void provideEvent(ManuvrRunnable*);
+    virtual void provideEvent(ManuvrMsg*);
 
     // Mandatory overrides
     virtual int serialize(StringBuilder*) =0;       // Returns the number of bytes resulting.
@@ -126,8 +126,8 @@ class XenoMessage {
   protected:
     uint32_t  bytes_received;  // How many bytes of this command have we received? Meaningless for the sender.
     uint32_t  bytes_total;     // How many bytes does this message occupy on the wire?
-    ManuvrRunnable* event;     // Associates this XenoMessage to an event.
-    ManuvrRunnable  _timeout;    // Occasionally, we must let a defunct message die on the wire...
+    ManuvrMsg* event;     // Associates this XenoMessage to an event.
+    ManuvrMsg  _timeout;    // Occasionally, we must let a defunct message die on the wire...
     uint8_t         proc_state;  // Where are we in the flow of this message? See XENO_MSG_PROC_STATES
 
 

--- a/ManuvrOS/XenoSession/XenoMessage.h
+++ b/ManuvrOS/XenoSession/XenoMessage.h
@@ -26,9 +26,11 @@ XenoMessage is the class that unifies our counterparty's message format
 #ifndef __XENOMESSAGE_H__
 #define __XENOMESSAGE_H__
 
-#include <Kernel.h>
+#include <CommonConstants.h>
 #include <EnumeratedTypeCodes.h>
-#include <Transports/ManuvrXport.h>
+#include <ManuvrMsg/ManuvrMsg.h>
+
+class XenoSession;
 
 #include <map>
 

--- a/ManuvrOS/XenoSession/XenoSession.cpp
+++ b/ManuvrOS/XenoSession/XenoSession.cpp
@@ -239,7 +239,7 @@ int8_t XenoSession::untapAll() {
 * @param  event  The event for which service has been completed.
 * @return A callback return code.
 */
-int8_t XenoSession::callback_proc(ManuvrRunnable *event) {
+int8_t XenoSession::callback_proc(ManuvrMsg* event) {
   /* Setup the default return code. If the event was marked as mem_managed, we return a DROP code.
      Otherwise, we will return a REAP code. Downstream of this assignment, we might choose differently. */
   int8_t return_value = event->kernelShouldReap() ? EVENT_CALLBACK_RETURN_REAP : EVENT_CALLBACK_RETURN_DROP;
@@ -266,7 +266,7 @@ int8_t XenoSession::callback_proc(ManuvrRunnable *event) {
 *   a list of events that it has been instructed to relay to the counterparty. If the event
 *   meets the relay criteria, we serialize it and send it to the transport that we are bound to.
 */
-int8_t XenoSession::notify(ManuvrRunnable *active_event) {
+int8_t XenoSession::notify(ManuvrMsg* active_event) {
   int8_t return_value = 0;
 
   switch (active_event->eventCode()) {
@@ -401,7 +401,7 @@ int XenoSession::purgeInbound() {
 * Passing an Event into this fxn will cause the Event to be serialized and sent to our counter-party.
 * This is the point at which choices are made about what happens to the event's life-cycle.
 */
-int8_t XenoSession::sendEvent(ManuvrRunnable *active_event) {
+int8_t XenoSession::sendEvent(ManuvrMsg* active_event) {
   //XenoMessage* nu_outbound_msg = XenoMessage::fetchPreallocation(this);
   //nu_outbound_msg->provideEvent(active_event);
 
@@ -415,7 +415,7 @@ int8_t XenoSession::sendEvent(ManuvrRunnable *active_event) {
   //}
 
   // We are about to pass a message across the transport.
-  //ManuvrRunnable* event = Kernel::returnEvent(MANUVR_MSG_XPORT_SEND);
+  //ManuvrMsg* event = Kernel::returnEvent(MANUVR_MSG_XPORT_SEND);
   //event->originator      = this;   // We want the callback and the only receiver of this
   //event->specific_target = owner;  //   event to be the transport that instantiated us.
   //raiseEvent(event);

--- a/ManuvrOS/XenoSession/XenoSession.cpp
+++ b/ManuvrOS/XenoSession/XenoSession.cpp
@@ -521,6 +521,6 @@ void XenoSession::procDirectDebugInstruction(StringBuilder *input) {
       break;
   }
 
-  if (local_log.length() > 0) {    Kernel::log(&local_log);  }
+  flushLocalLog();
 }
 #endif  // MANUVR_CONSOLE_SUPPORT

--- a/ManuvrOS/XenoSession/XenoSession.h
+++ b/ManuvrOS/XenoSession/XenoSession.h
@@ -74,7 +74,7 @@ class XenoSession : public EventReceiver, public BufferPipe {
     int8_t untapMessageType(uint16_t code);   // Stop getting broadcasts about a given message type.
     int8_t untapAll();
 
-    virtual int8_t sendEvent(ManuvrRunnable*);
+    virtual int8_t sendEvent(ManuvrMsg*);
 
     /* Returns and isolates the lifecycle phase bits. */
     inline uint8_t getPhase() {      return (session_state & 0x00FF);    };
@@ -97,8 +97,8 @@ class XenoSession : public EventReceiver, public BufferPipe {
 
     /* Overrides from EventReceiver */
     virtual void printDebug(StringBuilder*);
-    virtual int8_t notify(ManuvrRunnable*);
-    virtual int8_t callback_proc(ManuvrRunnable *);
+    virtual int8_t notify(ManuvrMsg*);
+    virtual int8_t callback_proc(ManuvrMsg*);
     #if defined(MANUVR_CONSOLE_SUPPORT)
       virtual void procDirectDebugInstruction(StringBuilder *);
     #endif
@@ -136,7 +136,7 @@ class XenoSession : public EventReceiver, public BufferPipe {
     LinkedList<XenoMessage*> _outbound_messages;   // Messages that are bound for the counterparty.
     LinkedList<XenoMessage*> _inbound_messages;    // Messages that came from the counterparty.
 
-    ManuvrRunnable _session_service;
+    ManuvrMsg _session_service;
 
     std::map<uint16_t, MessageTypeDef*> _relay_list;     // Which message codes will we relay to the counterparty?
     std::map<uint16_t, XenoMessage*>    _pending_exec;   // Messages pending execution (waiting on us).

--- a/doc/Lifecycles.md
+++ b/doc/Lifecycles.md
@@ -2,7 +2,7 @@
 
 ### EventReceiver
 
-### Runnable
+### ManuvrMsg
 
 ### BufferPipe
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,8 +2,6 @@
 # Makefile for libraries
 # Author: J. Ian Lindsay
 ###########################################################################
-
-# Build all libraries
 C_STANDARD   = gnu99
 CPP_STANDARD = gnu++11
 

--- a/main.cpp
+++ b/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, const char *argv[]) {
       kernel->subscribe(&mqtt);
 
       #if defined(RASPI) || defined(RASPI2)
-        ManuvrRunnable gpio_write(MANUVR_MSG_DIGITAL_WRITE);
+        ManuvrMsg gpio_write(MANUVR_MSG_DIGITAL_WRITE);
         gpio_write.isManaged(true);
         gpio_write.specific_target = &gpio;
         mqtt.subscribe("gw", &gpio_write);
@@ -199,7 +199,7 @@ int main(int argc, const char *argv[]) {
         mqtt.tapMessageType(MANUVR_MSG_DIGITAL_READ);
       #endif
 
-      ManuvrRunnable debug_msg(MANUVR_MSG_USER_DEBUG_INPUT);
+      ManuvrMsg debug_msg(MANUVR_MSG_USER_DEBUG_INPUT);
       debug_msg.isManaged(true);
       debug_msg.specific_target = (EventReceiver*) kernel;
 

--- a/tests/IdentityTest.cpp
+++ b/tests/IdentityTest.cpp
@@ -93,6 +93,7 @@ int UUID_IDENT_TESTS() {
 
 
 int CRYPTO_IDENT_TESTS() {
+  #if defined(__HAS_CRYPT_WRAPPER)
   int return_value = -1;
   StringBuilder log("===< CRYPTO_IDENT_TESTS >===============================\n");
   // Create identities from nothing...
@@ -137,10 +138,14 @@ int CRYPTO_IDENT_TESTS() {
   log.concat("\n\n");
   printf((const char*) log.string());
   return return_value;
+  #else
+  return 0;
+  #endif //__HAS_IDENT_ONEID
 }
 
 
 int ONEID_IDENT_TESTS() {
+  #if defined(__HAS_IDENT_ONEID)
   int return_value = -1;
   StringBuilder log("===< ONEID_IDENT_TESTS >================================\n");
   // Create identities from nothing...
@@ -180,6 +185,9 @@ int ONEID_IDENT_TESTS() {
   log.concat("\n\n");
   printf((const char*) log.string());
   return return_value;
+  #else
+  return 0;
+  #endif //__HAS_IDENT_ONEID
 }
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ SOURCES_CPP   += SchedulerTest.cpp
 
 LOCAL_CXX_FLAGS  = $(CPP_FLAGS) -D_GNU_SOURCE
 
-LIBS  = -L$(OUTPUT_PATH) -L$(WHERE_I_AM)/lib -lstdc++ -lm
+LIBS  = -L$(OUTPUT_PATH) -L$(BUILD_ROOT)/lib -lstdc++ -lm
 LIBS += -lmanuvr -lextras -lpthread
 
 ###########################################################################

--- a/tests/TestDataStructures.cpp
+++ b/tests/TestDataStructures.cpp
@@ -555,7 +555,7 @@ void printTypeSizes() {
   output.concat("\n-- Messaging components:\n");
   output.concatf("\tEventReceiver         %u\n", sizeof(EventReceiver));
   output.concatf("\tManuvrMsg             %u\n", sizeof(ManuvrMsg));
-  output.concatf("\t  ManuvrRunnable      %u\n", sizeof(ManuvrRunnable));
+  output.concatf("\t  ManuvrMsg      %u\n", sizeof(ManuvrMsg));
 
   output.concat("\n-- Transports:\n");
   output.concatf("\tManuvrXport           %u\n", sizeof(ManuvrXport));


### PR DESCRIPTION
- Build system improvements (as always).
- Removal of deprecated Runnable namespace.
- Removal of deprecated members in Xport, Kernel, and EventReceiver.
- Removal of code supporting semantic legend feature that was ill-conceived. Will adopt OneIOTA strategy in the future.
- Condensation of threadedness into EventReceiver. Further generalization of thread support.
- Further-embracing C++11 in class defs.
